### PR TITLE
Implement `scaled_view`

### DIFF
--- a/examples/simple_spmm.cpp
+++ b/examples/simple_spmm.cpp
@@ -3,6 +3,9 @@
 #include <fmt/core.h>
 #include <fmt/ranges.h>
 
+template <spblas::matrix M>
+void matrix_check(M&&) {}
+
 int main(int argc, char** argv) {
   using namespace spblas;
   namespace md = spblas::__mdspan;
@@ -22,9 +25,9 @@ int main(int argc, char** argv) {
   md::mdspan b(b_values.data(), k, n);
   md::mdspan c(c_values.data(), m, n);
 
-  auto view = scaled(1.0f, b);
+  auto a_view = scaled_view(1.2f, a);
 
-  multiply(a, view, c);
+  multiply(a_view, b, c);
 
   fmt::print("{}\n", spblas::__backend::values(c));
 

--- a/examples/simple_spmm.cpp
+++ b/examples/simple_spmm.cpp
@@ -3,9 +3,6 @@
 #include <fmt/core.h>
 #include <fmt/ranges.h>
 
-template <spblas::matrix M>
-void matrix_check(M&&) {}
-
 int main(int argc, char** argv) {
   using namespace spblas;
   namespace md = spblas::__mdspan;
@@ -25,7 +22,7 @@ int main(int argc, char** argv) {
   md::mdspan b(b_values.data(), k, n);
   md::mdspan c(c_values.data(), m, n);
 
-  auto a_view = scaled_view(1.2f, a);
+  auto a_view = scaled(1.2f, a);
 
   multiply(a_view, b, c);
 

--- a/examples/simple_spmm.cpp
+++ b/examples/simple_spmm.cpp
@@ -22,7 +22,9 @@ int main(int argc, char** argv) {
   md::mdspan b(b_values.data(), k, n);
   md::mdspan c(c_values.data(), m, n);
 
-  multiply(a, b, c);
+  auto view = scaled(1.0f, b);
+
+  multiply(a, view, c);
 
   fmt::print("{}\n", spblas::__backend::values(c));
 

--- a/examples/simple_spmv.cpp
+++ b/examples/simple_spmv.cpp
@@ -16,7 +16,7 @@ int main(int argc, char** argv) {
   std::vector<float> b(100, 1);
   std::vector<float> c(100, 0);
 
-  float alpha = 2.0f;
+  float alpha = 1.2f;
   // c = a * alpha * b
   multiply(a, scaled(alpha, b), c);
 

--- a/include/spblas/algorithms/scaled_impl.hpp
+++ b/include/spblas/algorithms/scaled_impl.hpp
@@ -10,4 +10,9 @@ auto scaled(Scalar alpha, V&& v) {
   return scaled_view(alpha, std::forward<V>(v));
 }
 
+template <typename Scalar, matrix M>
+auto scaled(Scalar alpha, M&& m) {
+  return scaled_view(alpha, std::forward<M>(m));
+}
+
 } // namespace spblas

--- a/include/spblas/algorithms/scaled_impl.hpp
+++ b/include/spblas/algorithms/scaled_impl.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
 #include <spblas/concepts.hpp>
+#include <spblas/views/scaled_view.hpp>
 
 namespace spblas {
 
 template <typename Scalar, vector V>
 auto scaled(Scalar alpha, V&& v) {
-  return __ranges::views::transform(std::forward<V>(v),
-                                    [=](auto&& x) { return alpha * x; });
+  return scaled_view(alpha, std::forward<V>(v));
 }
 
 } // namespace spblas

--- a/include/spblas/backend/concepts.hpp
+++ b/include/spblas/backend/concepts.hpp
@@ -21,22 +21,6 @@ concept lookupable_matrix =
       { lookup(t, i, j) };
     };
 
-/*
-namespace __detail {
-
-template <typename T, std::size_t... Ns>
-decltype(auto) lookupable_impl_(T&& t, Ns... ns) {
-  return lookup(t, ns...);
-}
-
-} // namespace __detail
-
-template <std::size_t N, typename T>
-concept lookupable = requires(T& t) {
-  { __detail::lookupable_impl_(t, std::make_index_sequence<N>{}) }
-};
-*/
-
 template <typename T>
 concept lookupable_vector = requires(T& t, tensor_index_t<T> i) {
   { lookup(t, i) };

--- a/include/spblas/backend/concepts.hpp
+++ b/include/spblas/backend/concepts.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <spblas/backend/cpos.hpp>
-#include <spblas/concepts.hpp>
 #include <spblas/detail/types.hpp>
 
 namespace spblas {
@@ -15,16 +14,14 @@ namespace {
 
 template <typename T>
 concept lookupable_matrix =
-    spblas::matrix<T> &&
     requires(T& t, tensor_index_t<T> i, tensor_index_t<T> j) {
       { lookup(t, i, j) };
     };
 
 template <typename T>
-concept lookupable_vector =
-    spblas::vector<T> && requires(T& t, tensor_index_t<T> i) {
-      { lookup(t, i) };
-    };
+concept lookupable_vector = requires(T& t, tensor_index_t<T> i) {
+  { lookup(t, i) };
+};
 
 } // namespace
 

--- a/include/spblas/backend/concepts.hpp
+++ b/include/spblas/backend/concepts.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <spblas/backend/cpos.hpp>
+#include <spblas/concepts.hpp>
 #include <spblas/detail/types.hpp>
 
 namespace spblas {

--- a/include/spblas/backend/concepts.hpp
+++ b/include/spblas/backend/concepts.hpp
@@ -8,7 +8,10 @@ namespace spblas {
 namespace __backend {
 
 template <typename T>
-concept row_iterable = requires(T& r) { rows(r); };
+concept row_iterable = requires(T& t) { rows(t); };
+
+template <typename T>
+concept row_lookupable = requires(T& t) { lookup_row(t, tensor_index_t<T>{}); };
 
 namespace {
 
@@ -17,6 +20,22 @@ concept lookupable_matrix =
     requires(T& t, tensor_index_t<T> i, tensor_index_t<T> j) {
       { lookup(t, i, j) };
     };
+
+/*
+namespace __detail {
+
+template <typename T, std::size_t... Ns>
+decltype(auto) lookupable_impl_(T&& t, Ns... ns) {
+  return lookup(t, ns...);
+}
+
+} // namespace __detail
+
+template <std::size_t N, typename T>
+concept lookupable = requires(T& t) {
+  { __detail::lookupable_impl_(t, std::make_index_sequence<N>{}) }
+};
+*/
 
 template <typename T>
 concept lookupable_vector = requires(T& t, tensor_index_t<T> i) {

--- a/include/spblas/backend/cpos.hpp
+++ b/include/spblas/backend/cpos.hpp
@@ -6,6 +6,16 @@ namespace spblas {
 
 namespace __backend {
 
+struct size_fn_ {
+  template <typename T>
+    requires(spblas::is_tag_invocable_v<size_fn_, T>)
+  constexpr auto operator()(T&& t) const {
+    return spblas::tag_invoke(size_fn_{}, std::forward<T>(t));
+  }
+};
+
+inline constexpr auto size = size_fn_{};
+
 struct shape_fn_ {
   template <typename T>
     requires(spblas::is_tag_invocable_v<shape_fn_, T>)

--- a/include/spblas/backend/view_customizations.hpp
+++ b/include/spblas/backend/view_customizations.hpp
@@ -9,6 +9,12 @@ namespace spblas {
 
 template <matrix M>
   requires(__detail::is_csr_view_v<M>)
+auto tag_invoke(__backend::size_fn_, M&& m) {
+  return m.size();
+}
+
+template <matrix M>
+  requires(__detail::is_csr_view_v<M>)
 auto tag_invoke(__backend::shape_fn_, M&& m) {
   return m.shape();
 }
@@ -79,6 +85,12 @@ namespace __backend {
 
 template <vector V>
   requires(__ranges::random_access_range<V>)
+auto tag_invoke(__backend::size_fn_, V&& v) {
+  return __ranges::size(v);
+}
+
+template <vector V>
+  requires(__ranges::random_access_range<V>)
 auto tag_invoke(__backend::shape_fn_, V&& v) {
   return __ranges::size(v);
 }
@@ -110,6 +122,12 @@ struct tensor_traits<M> {
 };
 
 namespace __backend {
+
+template <matrix M>
+  requires(__detail::is_matrix_instantiation_of_mdspan_v<M>)
+auto tag_invoke(__backend::size_fn_, M&& m) {
+  return m.extent(0) * m.extent(1);
+}
 
 template <matrix M>
   requires(__detail::is_matrix_instantiation_of_mdspan_v<M>)

--- a/include/spblas/backend/view_customizations.hpp
+++ b/include/spblas/backend/view_customizations.hpp
@@ -7,19 +7,19 @@ namespace spblas {
 
 // Customization point implementations for csr_view.
 
-template <matrix M>
+template <typename M>
   requires(__detail::is_csr_view_v<M>)
 auto tag_invoke(__backend::size_fn_, M&& m) {
   return m.size();
 }
 
-template <matrix M>
+template <typename M>
   requires(__detail::is_csr_view_v<M>)
 auto tag_invoke(__backend::shape_fn_, M&& m) {
   return m.shape();
 }
 
-template <matrix M>
+template <typename M>
   requires(__detail::is_csr_view_v<M>)
 auto tag_invoke(__backend::values_fn_, M&& m) {
   return m.values();
@@ -27,7 +27,7 @@ auto tag_invoke(__backend::values_fn_, M&& m) {
 
 namespace {
 
-template <matrix M>
+template <typename M>
   requires(__detail::is_csr_view_v<M>)
 auto row(M&& m, typename std::remove_cvref_t<M>::index_type row_index) {
   using O = typename std::remove_cvref_t<M>::offset_type;
@@ -49,7 +49,7 @@ auto row(M&& m, typename std::remove_cvref_t<M>::index_type row_index) {
 
 } // namespace
 
-template <matrix M>
+template <typename M>
   requires(__detail::is_csr_view_v<M>)
 auto tag_invoke(__backend::rows_fn_, M&& m) {
   using I = typename std::remove_cvref_t<M>::index_type;
@@ -62,7 +62,7 @@ auto tag_invoke(__backend::rows_fn_, M&& m) {
   return __ranges::views::zip(row_indices, row_values);
 }
 
-template <matrix M>
+template <typename M>
   requires(__detail::is_csr_view_v<M>)
 auto tag_invoke(__backend::lookup_row_fn_, M&& m,
                 typename std::remove_cvref_t<M>::index_type row_index) {
@@ -72,8 +72,7 @@ auto tag_invoke(__backend::lookup_row_fn_, M&& m,
 
 // Customization point implementations for vectors
 
-template <vector V>
-  requires(__ranges::random_access_range<V>)
+template <__ranges::random_access_range V>
 struct tensor_traits<V> {
   using scalar_type = __ranges::range_value_t<V>;
   using scalar_reference = __ranges::range_reference_t<V>;
@@ -83,26 +82,22 @@ struct tensor_traits<V> {
 
 namespace __backend {
 
-template <vector V>
-  requires(__ranges::random_access_range<V>)
+template <__ranges::random_access_range V>
 auto tag_invoke(__backend::size_fn_, V&& v) {
   return __ranges::size(v);
 }
 
-template <vector V>
-  requires(__ranges::random_access_range<V>)
+template <__ranges::random_access_range V>
 auto tag_invoke(__backend::shape_fn_, V&& v) {
   return __ranges::size(v);
 }
 
-template <vector V>
-  requires(__ranges::random_access_range<V>)
+template <__ranges::random_access_range V>
 auto tag_invoke(__backend::values_fn_, V&& v) {
   return __ranges::views::all(std::forward<V>(v));
 }
 
-template <vector V>
-  requires(__ranges::random_access_range<V>)
+template <__ranges::random_access_range V>
 __ranges::range_reference_t<V> tag_invoke(__backend::lookup_fn_, V&& v,
                                           __ranges::range_size_t<V> i) {
   return *(__ranges::begin(v) + i);
@@ -112,7 +107,7 @@ __ranges::range_reference_t<V> tag_invoke(__backend::lookup_fn_, V&& v,
 
 // Customization point implementations for mdspan
 
-template <matrix M>
+template <typename M>
   requires(__detail::is_matrix_instantiation_of_mdspan_v<M>)
 struct tensor_traits<M> {
   using scalar_type = typename std::remove_cvref_t<M>::value_type;
@@ -123,13 +118,13 @@ struct tensor_traits<M> {
 
 namespace __backend {
 
-template <matrix M>
+template <typename M>
   requires(__detail::is_matrix_instantiation_of_mdspan_v<M>)
 auto tag_invoke(__backend::size_fn_, M&& m) {
   return m.extent(0) * m.extent(1);
 }
 
-template <matrix M>
+template <typename M>
   requires(__detail::is_matrix_instantiation_of_mdspan_v<M>)
 auto tag_invoke(__backend::shape_fn_, M&& m) {
   using index_type = decltype(m.extent(0));
@@ -172,7 +167,7 @@ auto tag_invoke(__backend::rows_fn_,
   return __ranges::views::zip(row_indices, rows);
 }
 
-template <matrix M>
+template <typename M>
   requires(__detail::is_matrix_instantiation_of_mdspan_v<M>)
 tensor_scalar_reference_t<M> tag_invoke(__backend::lookup_fn_, M&& m,
                                         tensor_index_t<M> i,

--- a/include/spblas/concepts.hpp
+++ b/include/spblas/concepts.hpp
@@ -1,15 +1,29 @@
 #pragma once
 
 #include <concepts>
+#include <spblas/detail/concepts.hpp>
 #include <spblas/detail/ranges.hpp>
 #include <spblas/views/inspectors.hpp>
 #include <spblas/views/view_base.hpp>
 
 namespace spblas {
 
+/*
+  The following types fulfill the matrix concept:
+  - Instantiations of csr_view<...>
+  - Instantiations of mdspan<...> with rank 2
+  - Instantiations of scaled_view<T> where M is a matrix
+*/
+
 template <typename M>
-concept matrix = __detail::is_csr_view_v<M> ||
-                 __detail::is_matrix_instantiation_of_mdspan_v<M>;
+concept matrix =
+    __detail::is_csr_view_v<M> ||
+    __detail::is_matrix_instantiation_of_mdspan_v<M> || __detail::matrix<M>;
+
+/*
+  The following types fulfill the vector concept:
+  - Random access range (e.g. std::vector<...>)
+*/
 
 template <typename V>
 concept vector = __ranges::random_access_range<V> && !matrix<V>;

--- a/include/spblas/concepts.hpp
+++ b/include/spblas/concepts.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
-#include <spblas/views/views.hpp>
+#include <concepts>
+#include <spblas/detail/ranges.hpp>
+#include <spblas/views/inspectors.hpp>
+#include <spblas/views/view_base.hpp>
 
 namespace spblas {
 
@@ -10,5 +13,13 @@ concept matrix = __detail::is_csr_view_v<M> ||
 
 template <typename V>
 concept vector = __ranges::random_access_range<V> && !matrix<V>;
+
+template <typename T>
+concept tensor = matrix<T> || vector<T>;
+
+template <typename T>
+concept view = tensor<T> && (std::derived_from<T, view_base> ||
+                             __detail::is_matrix_instantiation_of_mdspan_v<T> ||
+                             __detail::view<T>);
 
 } // namespace spblas

--- a/include/spblas/detail/concepts.hpp
+++ b/include/spblas/detail/concepts.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <spblas/backend/cpos.hpp>
+
+#include <any>
+#include <concepts>
+#include <iterator>
+
+#include <spblas/detail/tuple_concept.hpp>
+
+namespace spblas {
+
+namespace __detail {
+
+template <typename M>
+concept matrix = requires(M& m) {
+  { __backend::size(m) } -> std::weakly_incrementable;
+  { __backend::shape(m) } -> tuple_like<std::size_t, std::size_t>;
+};
+
+}
+
+} // namespace spblas

--- a/include/spblas/detail/mdspan.hpp
+++ b/include/spblas/detail/mdspan.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <version>
+
 #if __has_include(<mdspan>)
 #include <mdspan>
 #endif

--- a/include/spblas/detail/ranges.hpp
+++ b/include/spblas/detail/ranges.hpp
@@ -7,9 +7,16 @@
 
 namespace spblas {
 
-namespace __ranges = std::ranges;
+namespace __ranges = ::std::ranges;
+
+namespace __detail {
+
+template <typename T>
+concept view = ::std::ranges::view<T>;
 
 }
+
+} // namespace spblas
 
 #elif __has_include(<range/v3/all.hpp>)
 
@@ -19,7 +26,14 @@ namespace spblas {
 
 namespace __ranges = ::ranges;
 
+namespace __detail {
+
+template <typename T>
+concept view = ::ranges::view_<T>;
+
 }
+
+} // namespace spblas
 
 #else
 static_assert(

--- a/include/spblas/detail/ranges.hpp
+++ b/include/spblas/detail/ranges.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <version>
+
 #if defined(__cpp_lib_ranges) && __cpp_lib_ranges >= 201911L &&                \
     defined(__cpp_lib_ranges_zip) && __cpp_lib_ranges_zip >= 202110L
 

--- a/include/spblas/detail/tuple_concept.hpp
+++ b/include/spblas/detail/tuple_concept.hpp
@@ -3,6 +3,7 @@
 #include <any>
 #include <concepts>
 #include <iterator>
+#include <tuple>
 
 namespace spblas {
 

--- a/include/spblas/detail/tuple_concept.hpp
+++ b/include/spblas/detail/tuple_concept.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <any>
+#include <concepts>
+#include <iterator>
+
+namespace spblas {
+
+namespace __detail {
+
+template <typename T, std::size_t I, typename U = std::any>
+concept tuple_element_gettable = requires(T tuple) {
+  { get<I>(tuple) } -> std::convertible_to<U>;
+};
+
+template <typename T, typename... Args>
+concept tuple_like =
+    requires {
+      typename std::tuple_size<std::remove_cvref_t<T>>::type;
+      requires std::same_as<
+          std::remove_cvref_t<
+              decltype(std::tuple_size_v<std::remove_cvref_t<T>>)>,
+          std::size_t>;
+    } && sizeof...(Args) == std::tuple_size_v<std::remove_cvref_t<T>> &&
+    []<std::size_t... I>(std::index_sequence<I...>) {
+      return (tuple_element_gettable<T, I, Args> && ...);
+    }(std::make_index_sequence<std::tuple_size_v<std::remove_cvref_t<T>>>());
+
+} // namespace __detail
+} // namespace spblas

--- a/include/spblas/views/csr_view.hpp
+++ b/include/spblas/views/csr_view.hpp
@@ -2,6 +2,7 @@
 
 #include <span>
 #include <spblas/detail/detail.hpp>
+#include <spblas/views/view_base.hpp>
 
 namespace spblas {
 
@@ -9,7 +10,7 @@ template <typename T, typename I, typename O>
 class csr_builder;
 
 template <typename T, std::integral I = index_t, std::integral O = I>
-class csr_view {
+class csr_view : public view_base {
 public:
   using scalar_type = T;
   using scalar_reference = T&;

--- a/include/spblas/views/inspectors.hpp
+++ b/include/spblas/views/inspectors.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <spblas/detail/mdspan.hpp>
-#include <spblas/views/views.hpp>
+#include <spblas/views/csr_view.hpp>
 
 namespace spblas {
 

--- a/include/spblas/views/inspectors.hpp
+++ b/include/spblas/views/inspectors.hpp
@@ -2,6 +2,7 @@
 
 #include <spblas/detail/mdspan.hpp>
 #include <spblas/views/csr_view.hpp>
+#include <spblas/views/scaled_view.hpp>
 
 namespace spblas {
 

--- a/include/spblas/views/scaled_view.hpp
+++ b/include/spblas/views/scaled_view.hpp
@@ -6,144 +6,30 @@
 
 namespace spblas {
 
-// NOTE: std::linalg refers to `ScalingFactor` type with name `alpha`.
-// Here, I write `S` instead of `ScalingFactor`.
-
 // Scale a tensor of type `T` by a scaling factor of type `S`.
 template <typename S, typename T>
 class scaled_view;
 
-// Scaled view for random access range
-template <typename S, vector V>
-  requires(__detail::view<V> && __ranges::random_access_range<V>)
-class scaled_view<S, V> : public view_base {
-public:
-  using scalar_type =
-      decltype(std::declval<S>() * std::declval<tensor_scalar_t<V>>());
-  using scalar_reference = scalar_type;
-  using index_type = tensor_index_t<V>;
-  using offset_type = tensor_offset_t<V>;
+namespace __detail {
 
-  scaled_view(S alpha, V vector)
-      : alpha_(alpha), vector_(vector),
-        transform_view_(vector, transform_fn_(alpha)) {}
-
-  index_type shape() const noexcept {
-    return __backend::shape(base());
-  }
-
-  index_type size() const noexcept {
-    return __backend::size(base());
-  }
-
-  S alpha() const noexcept {
-    return alpha_;
-  }
-
-  scalar_type operator[](index_type i) const {
-    return transform_view_[i];
-  }
-
-  auto base() {
-    return vector_;
-  }
-
-  auto base() const {
-    return vector_;
-  }
-
-  auto begin() {
-    return transform_view_.begin();
-  }
-
-  auto begin() const {
-    return transform_view_.begin();
-  }
-
-  auto end() {
-    return transform_view_.end();
-  }
-
-  auto end() const {
-    return transform_view_.end();
-  }
-
-private:
-  struct transform_fn_ {
-    transform_fn_(S alpha) : alpha_(alpha) {}
-
-    auto operator()(auto x) {
-      return alpha_ * x;
-    }
-
-  private:
-    S alpha_;
-  };
-
-  __ranges::transform_view<V, transform_fn_> transform_view_;
-
-private:
-  S alpha_;
-  V vector_;
+template <typename T>
+struct is_instantiation_of_scaled_view {
+  static constexpr bool value = false;
 };
 
-template <typename S, __ranges::random_access_range R>
-scaled_view(S alpha, R&& r) -> scaled_view<S, __ranges::views::all_t<R>>;
-
-// Scaled view for mdspan
-template <typename S, matrix M>
-  requires(view<M> && __backend::lookupable<M>)
-class scaled_view<S, M> : public view_base {
-public:
-  using scalar_type =
-      decltype(std::declval<S>() * std::declval<tensor_scalar_t<M>>());
-  using scalar_reference = scalar_type;
-  using index_type = tensor_index_t<M>;
-  using offset_type = tensor_offset_t<M>;
-
-  scaled_view(S alpha, M matrix) : alpha_(alpha), matrix_(matrix) {}
-
-  auto shape() const noexcept {
-    return __backend::shape(base());
-  }
-
-  index_type size() const noexcept {
-    return __backend::size(base());
-  }
-
-  S alpha() const noexcept {
-    return alpha_;
-  }
-
-  auto base() {
-    return matrix_;
-  }
-
-  auto base() const {
-    return matrix_;
-  }
-
-private:
-  friend auto tag_invoke(__backend::size_fn_, scaled_view matrix) {
-    return __backend::size(matrix.base());
-  }
-
-  friend auto tag_invoke(__backend::shape_fn_, scaled_view matrix) {
-    return __backend::shape(matrix.base());
-  }
-
-  friend auto tag_invoke(__backend::lookup_fn_, scaled_view matrix,
-                         index_type i, index_type j) {
-    return matrix.alpha() * __backend::lookup(matrix.base(), i, j);
-  }
-
-private:
-  S alpha_;
-  M matrix_;
+template <typename S, typename T>
+struct is_instantiation_of_scaled_view<scaled_view<S, T>> {
+  static constexpr bool value = true;
 };
 
-template <typename S, matrix M>
-  requires(view<M> && __backend::lookupable<M>)
-scaled_view(S s, M m) -> scaled_view<S, M>;
+template <typename T>
+static constexpr bool is_scaled_view_v =
+    is_instantiation_of_scaled_view<std::remove_cvref_t<T>>::value;
+
+template <typename T>
+static constexpr bool is_scaled_view_matrix_v =
+    is_scaled_view_v<T> && matrix<decltype(std::declval<T>().base())>;
+
+} // namespace __detail
 
 } // namespace spblas

--- a/include/spblas/views/scaled_view.hpp
+++ b/include/spblas/views/scaled_view.hpp
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <spblas/backend/concepts.hpp>
+#include <spblas/backend/cpos.hpp>
+#include <spblas/concepts.hpp>
+
+namespace spblas {
+
+// NOTE: std::linalg refers to `ScalingFactor` type with name `alpha`.
+// Here, I write `S` instead of `ScalingFactor`.
+
+// Scale a tensor of type `T` by a scaling factor of type `S`.
+template <typename S, typename T>
+class scaled_view;
+
+template <typename S, vector V>
+  requires(__detail::view<V>)
+class scaled_view<S, V> : public view_base {
+public:
+  using scalar_type =
+      decltype(std::declval<S>() * std::declval<tensor_scalar_t<V>>());
+  using scalar_reference = scalar_type;
+  using index_type = tensor_index_t<V>;
+  using offset_type = tensor_offset_t<V>;
+
+  scaled_view(S alpha, V vector)
+      : alpha_(alpha), vector_(vector),
+        transform_view_(vector, transform_fn_(alpha)) {}
+
+  index_type shape() const noexcept {
+    return __backend::shape(base());
+  }
+
+  index_type size() const noexcept {
+    return __backend::size(base());
+  }
+
+  S alpha() const noexcept {
+    return alpha_;
+  }
+
+  scalar_type operator[](index_type i) const {
+    return transform_view_[i];
+  }
+
+  auto base() {
+    return vector_;
+  }
+
+  auto base() const {
+    return vector_;
+  }
+
+  auto begin() {
+    return transform_view_.begin();
+  }
+
+  auto begin() const {
+    return transform_view_.begin();
+  }
+
+  auto end() {
+    return transform_view_.end();
+  }
+
+  auto end() const {
+    return transform_view_.end();
+  }
+
+private:
+  struct transform_fn_ {
+    transform_fn_(S alpha) : alpha_(alpha) {}
+
+    auto operator()(auto x) {
+      return alpha_ * x;
+    }
+
+  private:
+    S alpha_;
+  };
+
+  __ranges::transform_view<V, transform_fn_> transform_view_;
+
+private:
+  S alpha_;
+  V vector_;
+};
+
+template <typename S, __ranges::random_access_range R>
+scaled_view(S alpha, R&& r) -> scaled_view<S, __ranges::views::all_t<R>>;
+
+} // namespace spblas

--- a/include/spblas/views/scaled_view_impl.hpp
+++ b/include/spblas/views/scaled_view_impl.hpp
@@ -1,0 +1,187 @@
+#pragma once
+
+#include <spblas/backend/concepts.hpp>
+#include <spblas/backend/cpos.hpp>
+#include <spblas/concepts.hpp>
+#include <spblas/views/scaled_view.hpp>
+
+namespace spblas {
+
+// NOTE: std::linalg refers to `ScalingFactor` type with name `alpha`.
+// Here, I write `S` instead of `ScalingFactor`.
+
+// Scale a tensor of type `T` by a scaling factor of type `S`.
+template <typename S, typename T>
+class scaled_view;
+
+// Scaled view for random access range
+template <typename S, vector V>
+  requires(__detail::view<V> && __ranges::random_access_range<V>)
+class scaled_view<S, V> : public view_base {
+public:
+  using scalar_type =
+      decltype(std::declval<S>() * std::declval<tensor_scalar_t<V>>());
+  using scalar_reference = scalar_type;
+  using index_type = tensor_index_t<V>;
+  using offset_type = tensor_offset_t<V>;
+
+  scaled_view(S alpha, V vector)
+      : alpha_(alpha), vector_(vector),
+        transform_view_(vector, transform_fn_(alpha)) {}
+
+  index_type shape() const noexcept {
+    return __backend::shape(base());
+  }
+
+  index_type size() const noexcept {
+    return __backend::size(base());
+  }
+
+  S alpha() const noexcept {
+    return alpha_;
+  }
+
+  scalar_type operator[](index_type i) const {
+    return transform_view_[i];
+  }
+
+  auto base() {
+    return vector_;
+  }
+
+  auto base() const {
+    return vector_;
+  }
+
+  auto begin() {
+    return transform_view_.begin();
+  }
+
+  auto begin() const {
+    return transform_view_.begin();
+  }
+
+  auto end() {
+    return transform_view_.end();
+  }
+
+  auto end() const {
+    return transform_view_.end();
+  }
+
+private:
+  struct transform_fn_ {
+    transform_fn_(S alpha) : alpha_(alpha) {}
+
+    auto operator()(auto x) {
+      return alpha_ * x;
+    }
+
+  private:
+    S alpha_;
+  };
+
+  __ranges::transform_view<V, transform_fn_> transform_view_;
+
+private:
+  S alpha_;
+  V vector_;
+};
+
+template <typename S, __ranges::random_access_range R>
+scaled_view(S alpha, R&& r) -> scaled_view<S, __ranges::views::all_t<R>>;
+
+// Scaled view for matrices
+template <typename S, matrix M>
+  requires(view<M>)
+class scaled_view<S, M> : public view_base {
+public:
+  using scalar_type =
+      decltype(std::declval<S>() * std::declval<tensor_scalar_t<M>>());
+  using scalar_reference = scalar_type;
+  using index_type = tensor_index_t<M>;
+  using offset_type = tensor_offset_t<M>;
+
+  scaled_view(S alpha, M matrix) : alpha_(alpha), matrix_(matrix) {}
+
+  auto shape() const noexcept {
+    return __backend::shape(base());
+  }
+
+  index_type size() const noexcept {
+    return __backend::size(base());
+  }
+
+  S alpha() const noexcept {
+    return alpha_;
+  }
+
+  auto base() {
+    return matrix_;
+  }
+
+  auto base() const {
+    return matrix_;
+  }
+
+private:
+  friend auto tag_invoke(__backend::size_fn_, scaled_view matrix) {
+    return __backend::size(matrix.base());
+  }
+
+  friend auto tag_invoke(__backend::shape_fn_, scaled_view matrix) {
+    return __backend::shape(matrix.base());
+  }
+
+  friend auto tag_invoke(__backend::lookup_fn_, scaled_view matrix,
+                         index_type i, index_type j)
+    requires(__backend::lookupable<M>)
+  {
+    return matrix.alpha() * __backend::lookup(matrix.base(), i, j);
+  }
+
+  friend auto tag_invoke(__backend::rows_fn_, scaled_view matrix)
+    requires(__backend::row_iterable<M>)
+  {
+    S alpha = matrix.alpha();
+    auto unscaled_rows = __backend::rows(matrix.base());
+
+    return unscaled_rows |
+           __ranges::views::transform([alpha](auto&& row_tuple) {
+             auto&& [column_index, row] = row_tuple;
+
+             auto scaled_row =
+                 row |
+                 __ranges::views::transform([alpha](auto&& element_tuple) {
+                   auto&& [column_index, value] = element_tuple;
+                   return std::pair(column_index, alpha * value);
+                 });
+
+             return std::pair(column_index, scaled_row);
+           });
+  }
+
+  friend auto tag_invoke(__backend::lookup_row_fn_, scaled_view matrix,
+                         index_type row_index)
+    requires(__backend::row_lookupable<M>)
+  {
+    S alpha = matrix.alpha();
+    auto unscaled_row = __backend::lookup_row(matrix.base(), row_index);
+
+    return unscaled_row |
+           __ranges::views::transform([alpha](auto&& element_tuple) {
+             auto&& [column_index, value] = element_tuple;
+             return std::pair(column_index, alpha * value);
+           });
+  }
+
+private:
+  S alpha_;
+  M matrix_;
+};
+
+template <typename S, matrix M>
+  requires(view<M>)
+scaled_view(S s, M m) -> scaled_view<S, M>;
+
+} // namespace spblas

--- a/include/spblas/views/view_base.hpp
+++ b/include/spblas/views/view_base.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace spblas {
+
+class view_base {};
+
+} // namespace spblas

--- a/include/spblas/views/views.hpp
+++ b/include/spblas/views/views.hpp
@@ -3,4 +3,5 @@
 #include <spblas/views/csr_view.hpp>
 #include <spblas/views/inspectors.hpp>
 #include <spblas/views/scaled_view.hpp>
+#include <spblas/views/scaled_view_impl.hpp>
 #include <spblas/views/view_base.hpp>

--- a/include/spblas/views/views.hpp
+++ b/include/spblas/views/views.hpp
@@ -2,3 +2,5 @@
 
 #include <spblas/views/csr_view.hpp>
 #include <spblas/views/inspectors.hpp>
+#include <spblas/views/scaled_view.hpp>
+#include <spblas/views/view_base.hpp>

--- a/test/gtest/spgemm_test.cpp
+++ b/test/gtest/spgemm_test.cpp
@@ -7,8 +7,8 @@
 #include <fmt/ranges.h>
 
 TEST(CsrView, SpGEMM) {
-  using T = int;
-  using I = int;
+  using T = float;
+  using I = spblas::index_t;
 
   for (auto&& [m, k, nnz] : util::dims) {
     for (auto&& n : {m, k}) {
@@ -21,7 +21,7 @@ TEST(CsrView, SpGEMM) {
       spblas::csr_view<T, I> a(a_values, a_rowptr, a_colind, a_shape, a_nnz);
       spblas::csr_view<T, I> b(b_values, b_rowptr, b_colind, b_shape, b_nnz);
 
-      std::vector<T> c_rowptr(m + 1);
+      std::vector<I> c_rowptr(m + 1);
 
       spblas::csr_view<T, I> c(nullptr, c_rowptr.data(), nullptr, {m, n}, 0);
 
@@ -44,6 +44,116 @@ TEST(CsrView, SpGEMM) {
 
           for (auto&& [j, b_v] : b_row) {
             c_row_ref[j] += a_v * b_v;
+          }
+        }
+
+        auto&& c_row = spblas::__backend::lookup_row(c, i);
+
+        EXPECT_EQ(c_row_ref.size(), c_row.size());
+
+        for (auto&& [j, c_v] : c_row) {
+          EXPECT_EQ(c_row_ref[j], c_v);
+        }
+      }
+    }
+  }
+}
+
+TEST(CsrView, SpGEMM_AScaled) {
+  using T = float;
+  using I = spblas::index_t;
+
+  T alpha = 2.0f;
+
+  for (auto&& [m, k, nnz] : util::dims) {
+    for (auto&& n : {m, k}) {
+      auto [a_values, a_rowptr, a_colind, a_shape, a_nnz] =
+          spblas::generate_csr<T, I>(m, k, nnz);
+
+      auto [b_values, b_rowptr, b_colind, b_shape, b_nnz] =
+          spblas::generate_csr<T, I>(k, n, nnz);
+
+      spblas::csr_view<T, I> a(a_values, a_rowptr, a_colind, a_shape, a_nnz);
+      spblas::csr_view<T, I> b(b_values, b_rowptr, b_colind, b_shape, b_nnz);
+
+      std::vector<I> c_rowptr(m + 1);
+
+      spblas::csr_view<T, I> c(nullptr, c_rowptr.data(), nullptr, {m, n}, 0);
+
+      auto info = spblas::multiply_inspect(a, b, c);
+
+      std::vector<T> c_values(info.result_nnz());
+      std::vector<I> c_colind(info.result_nnz());
+
+      c.update(c_values, c_rowptr, c_colind);
+
+      spblas::multiply_execute(info, spblas::scaled(alpha, a), b, c);
+
+      spblas::__backend::spa_accumulator<T, I> c_row_ref(
+          spblas::__backend::shape(c)[1]);
+
+      for (auto&& [i, a_row] : spblas::__backend::rows(a)) {
+        c_row_ref.clear();
+        for (auto&& [k, a_v] : a_row) {
+          auto&& b_row = spblas::__backend::lookup_row(b, k);
+
+          for (auto&& [j, b_v] : b_row) {
+            c_row_ref[j] += alpha * a_v * b_v;
+          }
+        }
+
+        auto&& c_row = spblas::__backend::lookup_row(c, i);
+
+        EXPECT_EQ(c_row_ref.size(), c_row.size());
+
+        for (auto&& [j, c_v] : c_row) {
+          EXPECT_EQ(c_row_ref[j], c_v);
+        }
+      }
+    }
+  }
+}
+
+TEST(CsrView, SpGEMM_BScaled) {
+  using T = float;
+  using I = spblas::index_t;
+
+  T alpha = 2.0f;
+
+  for (auto&& [m, k, nnz] : util::dims) {
+    for (auto&& n : {m, k}) {
+      auto [a_values, a_rowptr, a_colind, a_shape, a_nnz] =
+          spblas::generate_csr<T, I>(m, k, nnz);
+
+      auto [b_values, b_rowptr, b_colind, b_shape, b_nnz] =
+          spblas::generate_csr<T, I>(k, n, nnz);
+
+      spblas::csr_view<T, I> a(a_values, a_rowptr, a_colind, a_shape, a_nnz);
+      spblas::csr_view<T, I> b(b_values, b_rowptr, b_colind, b_shape, b_nnz);
+
+      std::vector<I> c_rowptr(m + 1);
+
+      spblas::csr_view<T, I> c(nullptr, c_rowptr.data(), nullptr, {m, n}, 0);
+
+      auto info = spblas::multiply_inspect(a, b, c);
+
+      std::vector<T> c_values(info.result_nnz());
+      std::vector<I> c_colind(info.result_nnz());
+
+      c.update(c_values, c_rowptr, c_colind);
+
+      spblas::multiply_execute(info, a, spblas::scaled(alpha, b), c);
+
+      spblas::__backend::spa_accumulator<T, I> c_row_ref(
+          spblas::__backend::shape(c)[1]);
+
+      for (auto&& [i, a_row] : spblas::__backend::rows(a)) {
+        c_row_ref.clear();
+        for (auto&& [k, a_v] : a_row) {
+          auto&& b_row = spblas::__backend::lookup_row(b, k);
+
+          for (auto&& [j, b_v] : b_row) {
+            c_row_ref[j] += a_v * alpha * b_v;
           }
         }
 

--- a/test/gtest/spgemm_test.cpp
+++ b/test/gtest/spgemm_test.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include "util.hpp"
 #include <spblas/spblas.hpp>
 
 #include <fmt/core.h>
@@ -9,9 +10,7 @@ TEST(CsrView, SpGEMM) {
   using T = int;
   using I = int;
 
-  for (auto&& [m, k, nnz] :
-       {std::tuple(1000, 100, 100), std::tuple(100, 1000, 10000),
-        std::tuple(40, 40, 1000)}) {
+  for (auto&& [m, k, nnz] : util::dims) {
     for (auto&& n : {m, k}) {
       auto [a_values, a_rowptr, a_colind, a_shape, a_nnz] =
           spblas::generate_csr<T, I>(m, k, nnz);

--- a/test/gtest/spmm_test.cpp
+++ b/test/gtest/spmm_test.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include "util.hpp"
 #include <spblas/spblas.hpp>
 
 TEST(CsrView, SpMM) {
@@ -8,9 +9,7 @@ TEST(CsrView, SpMM) {
   using T = int;
   using I = int;
 
-  for (auto&& [m, k, nnz] :
-       {std::tuple(1000, 100, 100), std::tuple(100, 1000, 10000),
-        std::tuple(40, 40, 1000)}) {
+  for (auto&& [m, k, nnz] : util::dims) {
     for (auto&& n : {1, 8, 32, 64, 512}) {
       auto [values, rowptr, colind, shape, _] =
           spblas::generate_csr<T, I>(m, k, nnz);

--- a/test/gtest/spmv_test.cpp
+++ b/test/gtest/spmv_test.cpp
@@ -1,14 +1,13 @@
 #include <gtest/gtest.h>
 
+#include "util.hpp"
 #include <spblas/spblas.hpp>
 
 TEST(CsrView, SpMV) {
   using T = int;
   using I = int;
 
-  for (auto&& [m, n, nnz] :
-       {std::tuple(1000, 100, 100), std::tuple(100, 1000, 10000),
-        std::tuple(40, 40, 1000)}) {
+  for (auto&& [m, n, nnz] : util::dims) {
     auto [values, rowptr, colind, shape, _] =
         spblas::generate_csr<T, I>(m, n, nnz);
 

--- a/test/gtest/spmv_test.cpp
+++ b/test/gtest/spmv_test.cpp
@@ -4,8 +4,8 @@
 #include <spblas/spblas.hpp>
 
 TEST(CsrView, SpMV) {
-  using T = int;
-  using I = int;
+  using T = float;
+  using I = spblas::index_t;
 
   for (auto&& [m, n, nnz] : util::dims) {
     auto [values, rowptr, colind, shape, _] =
@@ -35,9 +35,45 @@ TEST(CsrView, SpMV) {
   }
 }
 
-TEST(CsrView, SpMV_Scaled) {
-  using T = int;
-  using I = int;
+TEST(CsrView, SpMV_AScaled) {
+  using T = float;
+  using I = spblas::index_t;
+
+  for (auto&& [m, n, nnz] :
+       {std::tuple(1000, 100, 100), std::tuple(100, 1000, 10000),
+        std::tuple(40, 40, 1000)}) {
+    for (auto&& alpha : {-10, 1, 5}) {
+      auto [values, rowptr, colind, shape, _] =
+          spblas::generate_csr<T, I>(m, n, nnz);
+
+      spblas::csr_view<T, I> a(values, rowptr, colind, shape, nnz);
+
+      std::vector<T> b(n, 1);
+      std::vector<T> c(m, 0);
+
+      spblas::multiply(spblas::scaled(alpha, a), b, c);
+
+      std::vector<T> c_ref(m, 0);
+
+      for (I i = 0; i < m; i++) {
+        for (I j_ptr = rowptr[i]; j_ptr < rowptr[i + 1]; j_ptr++) {
+          I j = colind[j_ptr];
+          T v = values[j_ptr];
+
+          c_ref[i] += v * alpha * b[j];
+        }
+      }
+
+      for (I i = 0; i < c_ref.size(); i++) {
+        EXPECT_EQ(c_ref[i], c[i]);
+      }
+    }
+  }
+}
+
+TEST(CsrView, SpMV_BScaled) {
+  using T = float;
+  using I = spblas::index_t;
 
   for (auto&& [m, n, nnz] :
        {std::tuple(1000, 100, 100), std::tuple(100, 1000, 10000),

--- a/test/gtest/util.hpp
+++ b/test/gtest/util.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <tuple>
+#include <vector>
+
+namespace util {
+
+inline auto dims =
+    std::vector({std::tuple(1000, 100, 100), std::tuple(100, 1000, 10000),
+                 std::tuple(40, 40, 1000)});
+
+}


### PR DESCRIPTION
This PR adds a dedicated `scaled_view` class, which will be returned by `scaled`.  A `scaled_view` represents a view of a vector or matrix that is symbolically scaled by an `alpha` scaling factor.

For backend implementers, the `scaled_view` has two essential parts to its interface:

- `view.base()`, which will return the base view the `scaled_view` was created on top of
- `view.alpha()`, which will return the scaling factor

The idea is that implementers will be able to write code like this:

```cpp
T alpha = 1.0;

if constexpr(__backend::is_scaled_view_impl_v<A>) {
  alpha = a.alpha();
  a_base = a.base();
} else {
  a_base = a;
}
```

Of course, the fact that views can be nested will make this slightly more complex, as there might be a `scaled_view` inside a `transpose_view` and vice-versa.  I plan on making a `retrieve_alpha` inspector that will iterate through a stack of views to find the scaling factor, if any, which should make vendor implementations much easier.

In my reference implementation, I expose the same high-level iteration methods that the underlying view has, if it has them.  For example, if the underlying view offers the `rows` customization point, the `scaled_view` will also offer `rows`, and its rows will return a scaled version of each row.