### PR TITLE
Add ArmPL vendor backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,14 @@ if (ENABLE_ONEMKL)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSPBLAS_ENABLE_ONEMKL")
 endif()
 
+if (ENABLE_ARMPL)
+  if (NOT DEFINED ENV{ARMPL_DIR})
+    message(FATAL_ERROR "Environment variable ARMPL_DIR must be set when the ArmPL is enabled.")
+  endif()
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSPBLAS_ENABLE_ARMPL -I$ENV{ARMPL_DIR}/include")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -L$ENV{ARMPL_DIR}/lib -larmpl -lamath -lm")
+endif()
+
 # mdspan
 FetchContent_Declare(
   mdspan

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ if (ENABLE_ARMPL)
   endif()
   target_include_directories(spblas INTERFACE $ENV{ARMPL_DIR}/include)
   target_link_libraries(spblas INTERFACE $ENV{ARMPL_DIR}/lib/libarmpl.a $ENV{ARMPL_DIR}/lib/libamath.a m)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSPBLAS_ENABLE_ARMPL")
 endif()
 
 # mdspan

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,8 @@ if (ENABLE_ARMPL)
   if (NOT DEFINED ENV{ARMPL_DIR})
     message(FATAL_ERROR "Environment variable ARMPL_DIR must be set when the ArmPL is enabled.")
   endif()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSPBLAS_ENABLE_ARMPL -I$ENV{ARMPL_DIR}/include")
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -L$ENV{ARMPL_DIR}/lib -larmpl -lamath -lm")
+  target_include_directories(spblas INTERFACE $ENV{ARMPL_DIR}/include)
+  target_link_libraries(spblas INTERFACE $ENV{ARMPL_DIR}/lib/libarmpl.a $ENV{ARMPL_DIR}/lib/libamath.a m)
 endif()
 
 # mdspan

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -7,4 +7,6 @@ add_example(simple_spmv)
 add_example(simple_spmm)
 add_example(simple_spgemm)
 
-add_subdirectory(armpl)
+if (ENABLE_ARMPL)
+  add_subdirectory(armpl)
+endif()

--- a/examples/armpl/CMakeLists.txt
+++ b/examples/armpl/CMakeLists.txt
@@ -3,8 +3,4 @@ function(add_example example_name)
   target_link_libraries(${example_name} spblas fmt)
 endfunction()
 
-add_example(simple_spmv)
-add_example(simple_spmm)
-add_example(simple_spgemm)
-
-add_subdirectory(armpl)
+add_example(armpl_example)

--- a/examples/armpl/armpl_example.cpp
+++ b/examples/armpl/armpl_example.cpp
@@ -1,6 +1,7 @@
-#include <armpl_sparse.h>
-#undef I
+#include <complex>
+
 #include <spblas/spblas.hpp>
+#include <spblas/vendor/armpl/detail/armpl.hpp>
 
 #include <fmt/ranges.h>
 

--- a/examples/armpl/armpl_example.cpp
+++ b/examples/armpl/armpl_example.cpp
@@ -1,0 +1,43 @@
+#include <armpl_sparse.h>
+#undef I
+#include <spblas/spblas.hpp>
+
+#include <fmt/ranges.h>
+
+int main(int argc, char** argv) {
+  using namespace spblas;
+
+  using T = float;
+  using I = std::int32_t;
+
+  auto&& [values, rowptr, colind, shape, nnz] =
+      generate_csr<T, I>(100, 100, 10);
+
+  csr_view<T, I> a(values, rowptr, colind, shape, nnz);
+
+  std::vector<T> b(100, 1);
+  std::vector<T> c(100, 0);
+
+  // multiply(a, b, c);
+
+  for (auto&& [i, row] : __backend::rows(a)) {
+    for (auto&& [k, v] : row) {
+      c[i] += v * b[k];
+    }
+  }
+
+  std::vector<T> c_armpl(100, 0);
+
+  armpl_spmat_t a_handle;
+  armpl_spmat_create_csr_s(&a_handle, a.shape()[0], a.shape()[1],
+                           a.rowptr().data(), a.colind().data(),
+                           a.values().data(), ARMPL_SPARSE_CREATE_NOCOPY);
+
+  auto stat = armpl_spmv_exec_s(ARMPL_SPARSE_OPERATION_NOTRANS, 1.0f, a_handle,
+                                b.data(), 0, c_armpl.data());
+
+  fmt::print("c (ref): {}\n", c);
+  fmt::print("c (arm): {}\n", c_armpl);
+
+  return 0;
+}

--- a/include/spblas/backend/backend.hpp
+++ b/include/spblas/backend/backend.hpp
@@ -9,3 +9,7 @@
 #ifdef SPBLAS_ENABLE_ONEMKL
 #include <spblas/vendor/mkl/mkl.hpp>
 #endif
+
+#ifdef SPBLAS_ENABLE_ARMPL
+#include <spblas/vendor/armpl/armpl.hpp>
+#endif

--- a/include/spblas/detail/operation_info_t.hpp
+++ b/include/spblas/detail/operation_info_t.hpp
@@ -7,6 +7,10 @@
 #include <spblas/vendor/mkl/operation_state_t.hpp>
 #endif
 
+#ifdef SPBLAS_ENABLE_ARMPL
+#include <spblas/vendor/armpl/operation_state_t.hpp>
+#endif
+
 namespace spblas {
 
 class operation_info_t {
@@ -29,6 +33,13 @@ public:
         state_(std::move(state)) {}
 #endif
 
+#ifdef SPBLAS_ENABLE_ARMPL
+  operation_info_t(index<> result_shape, index_t result_nnz,
+                   __armpl::operation_state_t&& state)
+      : result_shape_(result_shape), result_nnz_(result_nnz),
+        state_(std::move(state)) {}
+#endif
+
 private:
   index<> result_shape_;
   index_t result_nnz_;
@@ -36,6 +47,11 @@ private:
 #ifdef SPBLAS_ENABLE_ONEMKL
 public:
   __mkl::operation_state_t state_;
+#endif
+
+#ifdef SPBLAS_ENABLE_ARMPL
+public:
+  __armpl::operation_state_t state_;
 #endif
 };
 

--- a/include/spblas/detail/types.hpp
+++ b/include/spblas/detail/types.hpp
@@ -7,6 +7,10 @@
 #include <spblas/vendor/mkl/types.hpp>
 #endif
 
+#ifdef SPBLAS_ENABLE_ARMPL
+#include <spblas/vendor/armpl/types.hpp>
+#endif
+
 namespace spblas {
 
 #ifndef SPBLAS_VENDOR_BACKEND

--- a/include/spblas/detail/view_inspectors.hpp
+++ b/include/spblas/detail/view_inspectors.hpp
@@ -2,6 +2,7 @@
 
 #include <spblas/detail/concepts.hpp>
 #include <spblas/views/inspectors.hpp>
+#include <optional>
 
 namespace spblas {
 

--- a/include/spblas/detail/view_inspectors.hpp
+++ b/include/spblas/detail/view_inspectors.hpp
@@ -2,7 +2,6 @@
 
 #include <spblas/detail/concepts.hpp>
 #include <spblas/views/inspectors.hpp>
-#include <optional>
 
 namespace spblas {
 

--- a/include/spblas/spblas.hpp
+++ b/include/spblas/spblas.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#ifdef SPBLAS_ENABLE_ONEMKL
+#if defined(SPBLAS_ENABLE_ONEMKL) || defined(SPBLAS_ENABLE_ARMPL)
 #define SPBLAS_VENDOR_BACKEND true
 #endif
 

--- a/include/spblas/vendor/armpl/algorithms.hpp
+++ b/include/spblas/vendor/armpl/algorithms.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "multiply_impl.hpp"

--- a/include/spblas/vendor/armpl/armpl.hpp
+++ b/include/spblas/vendor/armpl/armpl.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "algorithms.hpp"

--- a/include/spblas/vendor/armpl/detail/armpl.hpp
+++ b/include/spblas/vendor/armpl/detail/armpl.hpp
@@ -11,7 +11,7 @@ namespace spblas {
 
 namespace __armpl {
 
-template <class T>
+template <typename T>
 armpl_status_t (*create_spmat_csr)(armpl_spmat_t*, armpl_int_t, armpl_int_t,
                                    const armpl_int_t*, const armpl_int_t*,
                                    const T*, armpl_int_t);
@@ -26,7 +26,7 @@ template <>
 inline constexpr auto create_spmat_csr<std::complex<double>> =
     &armpl_spmat_create_csr_z;
 
-template <class T>
+template <typename T>
 armpl_status_t (*create_spmat_dense)(armpl_spmat_t*, enum armpl_dense_layout,
                                      armpl_int_t, armpl_int_t, armpl_int_t,
                                      const float*, armpl_int_t);
@@ -41,7 +41,7 @@ template <>
 inline constexpr auto create_spmat_dense<std::complex<double>> =
     &armpl_spmat_create_dense_z;
 
-template <class T>
+template <typename T>
 armpl_status_t (*spmv_exec)(enum armpl_sparse_hint_value, T, armpl_spmat_t,
                             const T*, T, T*);
 template <>
@@ -53,7 +53,7 @@ inline constexpr auto spmv_exec<std::complex<float>> = &armpl_spmv_exec_c;
 template <>
 inline constexpr auto spmv_exec<std::complex<double>> = &armpl_spmv_exec_z;
 
-template <class T>
+template <typename T>
 armpl_status_t (*spmm_exec)(enum armpl_sparse_hint_value,
                             enum armpl_sparse_hint_value, T, armpl_spmat_t,
                             armpl_spmat_t, T, armpl_spmat_t);
@@ -65,6 +65,21 @@ template <>
 inline constexpr auto spmm_exec<std::complex<float>> = &armpl_spmm_exec_c;
 template <>
 inline constexpr auto spmm_exec<std::complex<double>> = &armpl_spmm_exec_z;
+
+template <typename T>
+armpl_status_t (*export_spmat_dense)(armpl_const_spmat_t,
+                                     enum armpl_dense_layout, armpl_int_t*,
+                                     armpl_int_t*, const T**);
+template <>
+inline constexpr auto export_spmat_dense<float> = &armpl_spmat_export_dense_s;
+template <>
+inline constexpr auto export_spmat_dense<double> = &armpl_spmat_export_dense_d;
+template <>
+inline constexpr auto export_spmat_dense<std::complex<float>> =
+    &armpl_spmat_export_dense_c;
+template <>
+inline constexpr auto export_spmat_dense<std::complex<double>> =
+    &armpl_spmat_export_dense_z;
 
 } // namespace __armpl
 

--- a/include/spblas/vendor/armpl/detail/armpl.hpp
+++ b/include/spblas/vendor/armpl/detail/armpl.hpp
@@ -81,6 +81,22 @@ template <>
 inline constexpr auto export_spmat_dense<std::complex<double>> =
     &armpl_spmat_export_dense_z;
 
+template <typename T>
+armpl_status_t (*export_spmat_csr)(armpl_const_spmat_t, armpl_int_t,
+                                   armpl_int_t*, armpl_int_t*,
+                                   const armpl_int_t**, const armpl_int_t**,
+                                   const T**);
+template <>
+inline constexpr auto export_spmat_csr<float> = &armpl_spmat_export_csr_s;
+template <>
+inline constexpr auto export_spmat_csr<double> = &armpl_spmat_export_csr_d;
+template <>
+inline constexpr auto export_spmat_csr<std::complex<float>> =
+    &armpl_spmat_export_csr_c;
+template <>
+inline constexpr auto export_spmat_csr<std::complex<double>> =
+    &armpl_spmat_export_csr_z;
+
 } // namespace __armpl
 
 } // namespace spblas

--- a/include/spblas/vendor/armpl/detail/armpl.hpp
+++ b/include/spblas/vendor/armpl/detail/armpl.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <complex>
+
+#define armpl_singlecomplex_t std::complex<float>
+#define armpl_doublecomplex_t std::complex<double>
+
+#include <armpl_sparse.h>
+
+namespace spblas {
+
+namespace __armpl {
+
+template <class T>
+armpl_status_t (*create_spmat_csr)(armpl_spmat_t*, armpl_int_t, armpl_int_t,
+                                   const armpl_int_t*, const armpl_int_t*,
+                                   const T*, armpl_int_t);
+template <>
+inline constexpr auto create_spmat_csr<float> = &armpl_spmat_create_csr_s;
+template <>
+inline constexpr auto create_spmat_csr<double> = &armpl_spmat_create_csr_d;
+template <>
+inline constexpr auto create_spmat_csr<std::complex<float>> =
+    &armpl_spmat_create_csr_c;
+template <>
+inline constexpr auto create_spmat_csr<std::complex<double>> =
+    &armpl_spmat_create_csr_z;
+
+template <class T>
+armpl_status_t (*create_spmat_dense)(armpl_spmat_t*, enum armpl_dense_layout,
+                                     armpl_int_t, armpl_int_t, armpl_int_t,
+                                     const float*, armpl_int_t);
+template <>
+inline constexpr auto create_spmat_dense<float> = &armpl_spmat_create_dense_s;
+template <>
+inline constexpr auto create_spmat_dense<double> = &armpl_spmat_create_dense_d;
+template <>
+inline constexpr auto create_spmat_dense<std::complex<float>> =
+    &armpl_spmat_create_dense_c;
+template <>
+inline constexpr auto create_spmat_dense<std::complex<double>> =
+    &armpl_spmat_create_dense_z;
+
+template <class T>
+armpl_status_t (*spmv_exec)(enum armpl_sparse_hint_value, T, armpl_spmat_t,
+                            const T*, T, T*);
+template <>
+inline constexpr auto spmv_exec<float> = &armpl_spmv_exec_s;
+template <>
+inline constexpr auto spmv_exec<double> = &armpl_spmv_exec_d;
+template <>
+inline constexpr auto spmv_exec<std::complex<float>> = &armpl_spmv_exec_c;
+template <>
+inline constexpr auto spmv_exec<std::complex<double>> = &armpl_spmv_exec_z;
+
+template <class T>
+armpl_status_t (*spmm_exec)(enum armpl_sparse_hint_value,
+                            enum armpl_sparse_hint_value, T, armpl_spmat_t,
+                            armpl_spmat_t, T, armpl_spmat_t);
+template <>
+inline constexpr auto spmm_exec<float> = &armpl_spmm_exec_s;
+template <>
+inline constexpr auto spmm_exec<double> = &armpl_spmm_exec_d;
+template <>
+inline constexpr auto spmm_exec<std::complex<float>> = &armpl_spmm_exec_c;
+template <>
+inline constexpr auto spmm_exec<std::complex<double>> = &armpl_spmm_exec_z;
+
+} // namespace __armpl
+
+} // namespace spblas

--- a/include/spblas/vendor/armpl/multiply_impl.hpp
+++ b/include/spblas/vendor/armpl/multiply_impl.hpp
@@ -71,6 +71,15 @@ void multiply(A&& a, B&& b, C&& c) {
                                          ARMPL_SPARSE_OPERATION_NOTRANS, alpha,
                                          a_handle, b_handle, 0, c_handle);
 
+  armpl_int_t m, n;
+  tensor_scalar_t<C>* armpl_values;
+  __armpl::export_spmat_dense<tensor_scalar_t<C>>(c_handle, ARMPL_ROW_MAJOR, &m,
+                                                  &n, &armpl_values);
+
+  std::copy(armpl_values, armpl_values + (m * n), c.data_handle());
+
+  free(armpl_values);
+
   armpl_spmat_destroy(a_handle);
   armpl_spmat_destroy(b_handle);
   armpl_spmat_destroy(c_handle);

--- a/include/spblas/vendor/armpl/multiply_impl.hpp
+++ b/include/spblas/vendor/armpl/multiply_impl.hpp
@@ -6,8 +6,6 @@
 #include <spblas/detail/ranges.hpp>
 #include <spblas/detail/view_inspectors.hpp>
 
-#include <fmt/ranges.h>
-
 namespace spblas {
 
 template <matrix A, vector B, vector C>

--- a/include/spblas/vendor/armpl/multiply_impl.hpp
+++ b/include/spblas/vendor/armpl/multiply_impl.hpp
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <spblas/vendor/armpl/detail/armpl.hpp>
+
+#include <spblas/detail/operation_info_t.hpp>
+#include <spblas/detail/ranges.hpp>
+#include <spblas/detail/view_inspectors.hpp>
+
+#include <fmt/ranges.h>
+
+namespace spblas {
+
+template <matrix A, vector B, vector C>
+  requires __detail::has_csr_base<A> &&
+           __detail::has_contiguous_range_base<B> &&
+           __ranges::contiguous_range<C>
+void multiply(A&& a, B&& b, C&& c) {
+  auto a_base = __detail::get_ultimate_base(a);
+  auto b_base = __detail::get_ultimate_base(b);
+
+  auto alpha_optional = __detail::get_scaling_factor(a, b);
+  tensor_scalar_t<A> alpha = alpha_optional.value_or(1);
+
+  armpl_spmat_t a_handle;
+
+  __armpl::create_spmat_csr<tensor_scalar_t<A>>(
+      &a_handle, __backend::shape(a_base)[0], __backend::shape(a_base)[1],
+      a_base.rowptr().data(), a_base.colind().data(), a_base.values().data(),
+      ARMPL_SPARSE_CREATE_NOCOPY);
+
+  auto stat = __armpl::spmv_exec<tensor_scalar_t<A>>(
+      ARMPL_SPARSE_OPERATION_NOTRANS, alpha, a_handle, __ranges::data(b), 0,
+      __ranges::data(c));
+
+  armpl_spmat_destroy(a_handle);
+}
+
+template <matrix A, matrix B, matrix C>
+  requires __detail::has_csr_base<A> && __detail::has_mdspan_matrix_base<B> &&
+           __detail::is_matrix_instantiation_of_mdspan_v<C> &&
+           std::is_same_v<
+               typename __detail::ultimate_base_type_t<B>::layout_type,
+               __mdspan::layout_right> &&
+           std::is_same_v<typename std::remove_cvref_t<C>::layout_type,
+                          __mdspan::layout_right>
+void multiply(A&& a, B&& b, C&& c) {
+  auto a_base = __detail::get_ultimate_base(a);
+  auto b_base = __detail::get_ultimate_base(b);
+
+  auto alpha_optional = __detail::get_scaling_factor(a, b);
+  tensor_scalar_t<A> alpha = alpha_optional.value_or(1);
+
+  armpl_spmat_t a_handle, b_handle, c_handle;
+
+  __armpl::create_spmat_csr<tensor_scalar_t<A>>(
+      &a_handle, __backend::shape(a_base)[0], __backend::shape(a_base)[1],
+      a_base.rowptr().data(), a_base.colind().data(), a_base.values().data(),
+      ARMPL_SPARSE_CREATE_NOCOPY);
+
+  __armpl::create_spmat_dense<tensor_scalar_t<B>>(
+      &b_handle, ARMPL_ROW_MAJOR, __backend::shape(b_base)[0],
+      __backend::shape(b_base)[1], __backend::shape(b_base)[1],
+      b_base.data_handle(), ARMPL_SPARSE_CREATE_NOCOPY);
+
+  __armpl::create_spmat_dense<tensor_scalar_t<C>>(
+      &c_handle, ARMPL_ROW_MAJOR, __backend::shape(c)[0],
+      __backend::shape(c)[1], __backend::shape(c)[1], c.data_handle(),
+      ARMPL_SPARSE_CREATE_NOCOPY);
+
+  __armpl::spmm_exec<tensor_scalar_t<A>>(ARMPL_SPARSE_OPERATION_NOTRANS,
+                                         ARMPL_SPARSE_OPERATION_NOTRANS, alpha,
+                                         a_handle, b_handle, 0, c_handle);
+
+  armpl_spmat_destroy(a_handle);
+  armpl_spmat_destroy(b_handle);
+  armpl_spmat_destroy(c_handle);
+}
+
+} // namespace spblas

--- a/include/spblas/vendor/armpl/multiply_impl.hpp
+++ b/include/spblas/vendor/armpl/multiply_impl.hpp
@@ -108,9 +108,44 @@ operation_info_t multiply_inspect(A&& a, B&& b, C&& c) {
   c_handle =
       armpl_spmat_create_null(__backend::shape(c)[0], __backend::shape(c)[1]);
 
+#if 0
+/*
+  Turns out, there is a problem with my suggestion here.
+  If either of the structure hints are set
+  (ARMPL_SPARSE_SPMM_STRAT_OPT_PART_STRUCT is used below), then
+  `armpl_spmm_optimize` will only have computed any of the
+  structure *if the rows of B are sorted*. Otherwise, we return early from
+  optimization and execution does everything. Since these are hints,
+  this is OK in our implementation. However, it means we can't rely on
+  calling `optimize` to *always* calculate NNZ for C in this `inspect`
+  function. The only way to guarantee NNZ is to execute.
+
+  If we do the sorting in here then we'll need to sort b_colind, and call
+  armpl::create_spmat_csr without ARMPL_SPARSE_CREATE_NOCOPY (flag=0 instead)
+  in which case b_colind_copy is copied again, along with taking copies of
+  b_rowptr and b_values. Seems excessive!
+*/
+
+  auto alpha_hint = alpha == 0 ? ARMPL_SPARSE_SCALAR_ZERO :
+                    alpha == 1 ? ARMPL_SPARSE_SCALAR_ONE :
+                                 ARMPL_SPARSE_SCALAR_ANY;
+
+  auto beta_hint = ARMPL_SPARSE_SCALAR_ZERO;
+
+  armpl_spmat_hint(c_handle, ARMPL_SPARSE_HINT_SPMM_STRATEGY,
+                   ARMPL_SPARSE_SPMM_STRAT_OPT_PART_STRUCT);
+
+  armpl_spmm_optimize(ARMPL_SPARSE_OPERATION_NOTRANS,
+                      ARMPL_SPARSE_OPERATION_NOTRANS,
+                      ARMPL_SPARSE_SCALAR_ONE, a_handle,
+                      b_handle, ARMPL_SPARSE_SCALAR_ZERO, c_handle);
+
+#else
+
   __armpl::spmm_exec<tensor_scalar_t<A>>(ARMPL_SPARSE_OPERATION_NOTRANS,
                                          ARMPL_SPARSE_OPERATION_NOTRANS, alpha,
                                          a_handle, b_handle, 0, c_handle);
+#endif
 
   armpl_int_t index_base, m, n, nnz;
   armpl_spmat_query(c_handle, &index_base, &m, &n, &nnz);
@@ -132,6 +167,17 @@ void multiply_execute(operation_info_t& info, A&& a, B&& b, C&& c) {
   auto nnz = info.result_nnz();
   armpl_int_t *rowptr, *colind;
   tensor_scalar_t<C>* values;
+
+#if 0
+  auto alpha_optional = __detail::get_scaling_factor(a, b);
+  tensor_scalar_t<A> alpha = alpha_optional.value_or(1);
+
+  // We would do this here instead if B's rows were guaranteed to be sorted
+  __armpl::spmm_exec<tensor_scalar_t<A>>(ARMPL_SPARSE_OPERATION_NOTRANS,
+                                         ARMPL_SPARSE_OPERATION_NOTRANS, alpha,
+                                         a_handle, b_handle, 0, c_handle);
+#endif
+
   __armpl::export_spmat_csr<tensor_scalar_t<C>>(c_handle, 0, &m, &n, &rowptr,
                                                 &colind, &values);
 

--- a/include/spblas/vendor/armpl/operation_state_t.hpp
+++ b/include/spblas/vendor/armpl/operation_state_t.hpp
@@ -4,7 +4,7 @@
 
 namespace spblas {
 
-namespace __mkl {
+namespace __armpl {
 
 struct operation_state_t {
   armpl_spmat_t a_handle = nullptr;
@@ -46,11 +46,11 @@ struct operation_state_t {
 private:
   void release_matrix_handle(armpl_spmat_t& handle) {
     if (handle != nullptr) {
-      armpl_spmat_destroy(q, &handle);
+      armpl_spmat_destroy(handle);
     }
   }
 };
 
-} // namespace __mkl
+} // namespace __armpl
 
 } // namespace spblas

--- a/include/spblas/vendor/armpl/operation_state_t.hpp
+++ b/include/spblas/vendor/armpl/operation_state_t.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <spblas/vendor/armpl/detail/armpl.hpp>
+
+namespace spblas {
+
+namespace __mkl {
+
+struct operation_state_t {
+  armpl_spmat_t a_handle = nullptr;
+  armpl_spmat_t b_handle = nullptr;
+  armpl_spmat_t c_handle = nullptr;
+  armpl_spmat_t d_handle = nullptr;
+
+  operation_state_t() = default;
+
+  operation_state_t(armpl_spmat_t a_handle, armpl_spmat_t b_handle,
+                    armpl_spmat_t c_handle, armpl_spmat_t d_handle)
+      : a_handle(a_handle), b_handle(b_handle), c_handle(c_handle),
+        d_handle(d_handle) {}
+
+  operation_state_t(operation_state_t&& other) {
+    *this = std::move(other);
+  }
+
+  operation_state_t& operator=(operation_state_t&& other) {
+    a_handle = other.a_handle;
+    b_handle = other.b_handle;
+    c_handle = other.c_handle;
+    d_handle = other.d_handle;
+
+    other.a_handle = other.b_handle = other.c_handle = other.d_handle = nullptr;
+
+    return *this;
+  }
+
+  operation_state_t(const operation_state_t& other) = delete;
+
+  ~operation_state_t() {
+    release_matrix_handle(a_handle);
+    release_matrix_handle(b_handle);
+    release_matrix_handle(c_handle);
+    release_matrix_handle(d_handle);
+  }
+
+private:
+  void release_matrix_handle(armpl_spmat_t& handle) {
+    if (handle != nullptr) {
+      armpl_spmat_destroy(q, &handle);
+    }
+  }
+};
+
+} // namespace __mkl
+
+} // namespace spblas

--- a/include/spblas/vendor/armpl/types.hpp
+++ b/include/spblas/vendor/armpl/types.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <cstdint>
+
+namespace spblas {
+
+using index_t = std::int32_t;
+
+}

--- a/include/spblas/vendor/armpl/types.hpp
+++ b/include/spblas/vendor/armpl/types.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
 #include <cstdint>
+#include <spblas/vendor/armpl/detail/armpl.hpp>
 
 namespace spblas {
 
-using index_t = std::int32_t;
+using index_t = armpl_int_t;
 
 }

--- a/test/gtest/spgemm_test.cpp
+++ b/test/gtest/spgemm_test.cpp
@@ -7,6 +7,8 @@
 #include <fmt/core.h>
 #include <fmt/ranges.h>
 
+#include <algorithm>
+
 TEST(CsrView, SpGEMM) {
   using T = float;
   using I = spblas::index_t;
@@ -18,6 +20,10 @@ TEST(CsrView, SpGEMM) {
 
       auto [b_values, b_rowptr, b_colind, b_shape, b_nnz] =
           spblas::generate_csr<T, I>(k, n, nnz);
+
+      for (int i=0; i<k; i++) {
+        std::sort(&b_colind[b_rowptr[i]], &b_colind[b_rowptr[i+1]]);
+      }
 
       spblas::csr_view<T, I> a(a_values, a_rowptr, a_colind, a_shape, a_nnz);
       spblas::csr_view<T, I> b(b_values, b_rowptr, b_colind, b_shape, b_nnz);
@@ -84,6 +90,10 @@ TEST(CsrView, SpGEMM_AScaled) {
       auto [b_values, b_rowptr, b_colind, b_shape, b_nnz] =
           spblas::generate_csr<T, I>(k, n, nnz);
 
+      for (int i=0; i<k; i++) {
+        std::sort(&b_colind[b_rowptr[i]], &b_colind[b_rowptr[i+1]]);
+      }
+
       spblas::csr_view<T, I> a(a_values, a_rowptr, a_colind, a_shape, a_nnz);
       spblas::csr_view<T, I> b(b_values, b_rowptr, b_colind, b_shape, b_nnz);
 
@@ -148,6 +158,10 @@ TEST(CsrView, SpGEMM_BScaled) {
 
       auto [b_values, b_rowptr, b_colind, b_shape, b_nnz] =
           spblas::generate_csr<T, I>(k, n, nnz);
+
+      for (int i=0; i<k; i++) {
+        std::sort(&b_colind[b_rowptr[i]], &b_colind[b_rowptr[i+1]]);
+      }
 
       spblas::csr_view<T, I> a(a_values, a_rowptr, a_colind, a_shape, a_nnz);
       spblas::csr_view<T, I> b(b_values, b_rowptr, b_colind, b_shape, b_nnz);

--- a/test/gtest/spgemm_test.cpp
+++ b/test/gtest/spgemm_test.cpp
@@ -91,7 +91,7 @@ TEST(CsrView, SpGEMM_AScaled) {
 
       spblas::csr_view<T, I> c(nullptr, c_rowptr.data(), nullptr, {m, n}, 0);
 
-      auto info = spblas::multiply_inspect(a, b, c);
+      auto info = spblas::multiply_inspect(spblas::scaled(alpha, a), b, c);
 
       std::vector<T> c_values(info.result_nnz());
       std::vector<I> c_colind(info.result_nnz());
@@ -156,7 +156,7 @@ TEST(CsrView, SpGEMM_BScaled) {
 
       spblas::csr_view<T, I> c(nullptr, c_rowptr.data(), nullptr, {m, n}, 0);
 
-      auto info = spblas::multiply_inspect(a, b, c);
+      auto info = spblas::multiply_inspect(a, spblas::scaled(alpha, b), c);
 
       std::vector<T> c_values(info.result_nnz());
       std::vector<I> c_colind(info.result_nnz());

--- a/test/gtest/spgemm_test.cpp
+++ b/test/gtest/spgemm_test.cpp
@@ -7,8 +7,6 @@
 #include <fmt/core.h>
 #include <fmt/ranges.h>
 
-#include <algorithm>
-
 TEST(CsrView, SpGEMM) {
   using T = float;
   using I = spblas::index_t;
@@ -20,10 +18,6 @@ TEST(CsrView, SpGEMM) {
 
       auto [b_values, b_rowptr, b_colind, b_shape, b_nnz] =
           spblas::generate_csr<T, I>(k, n, nnz);
-
-      for (int i=0; i<k; i++) {
-        std::sort(&b_colind[b_rowptr[i]], &b_colind[b_rowptr[i+1]]);
-      }
 
       spblas::csr_view<T, I> a(a_values, a_rowptr, a_colind, a_shape, a_nnz);
       spblas::csr_view<T, I> b(b_values, b_rowptr, b_colind, b_shape, b_nnz);
@@ -90,10 +84,6 @@ TEST(CsrView, SpGEMM_AScaled) {
       auto [b_values, b_rowptr, b_colind, b_shape, b_nnz] =
           spblas::generate_csr<T, I>(k, n, nnz);
 
-      for (int i=0; i<k; i++) {
-        std::sort(&b_colind[b_rowptr[i]], &b_colind[b_rowptr[i+1]]);
-      }
-
       spblas::csr_view<T, I> a(a_values, a_rowptr, a_colind, a_shape, a_nnz);
       spblas::csr_view<T, I> b(b_values, b_rowptr, b_colind, b_shape, b_nnz);
 
@@ -158,10 +148,6 @@ TEST(CsrView, SpGEMM_BScaled) {
 
       auto [b_values, b_rowptr, b_colind, b_shape, b_nnz] =
           spblas::generate_csr<T, I>(k, n, nnz);
-
-      for (int i=0; i<k; i++) {
-        std::sort(&b_colind[b_rowptr[i]], &b_colind[b_rowptr[i+1]]);
-      }
 
       spblas::csr_view<T, I> a(a_values, a_rowptr, a_colind, a_shape, a_nnz);
       spblas::csr_view<T, I> b(b_values, b_rowptr, b_colind, b_shape, b_nnz);


### PR DESCRIPTION
This PR adds an ArmPL vendor backend.  To build with the ArmPL backend, you need to:

- Install ArmPL and set the environment variable `ARMPL_DIR` (usually something like `ARMPL_DIR=/opt/arm/armpl_23.10_gcc-12.2`, and ArmPL's modulefiles should set this automatically if you use them)
- Compile with the CMake flag `-DENABLE_ARMPL=ON`.

This will trigger the inclusion of [implementations of `multiply` that will call ArmPL](https://github.com/SparseBLAS/spblas-reference/pull/13/files#diff-e0b594ffbf973cec91d97d167852a8f91182fb597ad6e3c9b8b798ecf671e6e8).  Similar to the oneMKL backend, this implementation adds an [`operation_state_t`](https://github.com/SparseBLAS/spblas-reference/pull/13/files#diff-f7e5a1ebf8e10da2f22c1c6cee8a732c20380a86eddcf40ad3462bb286654a09) struct that stores vendor-specific information (the `armpl_spmat_t` matrices).  This will be passed between the `multiply_inspect` and `multiply_execute` through the `operation_info_t` object.

ArmPL also [declares `spblas::index_t`](https://github.com/SparseBLAS/spblas-reference/pull/13/files#diff-30a485abe5f750da66638afbf3c1f0c4e3910f7dc403b1327f15a41d9a0f8cbf), which is a valid integer type that can be used for storing indices and offsets of sparse matrices.  It also has some [templated helpers](https://github.com/SparseBLAS/spblas-reference/pull/13/files#diff-df432b59a671f5b09ba6489dd97de63831b3feaf8523245e727616adb5284b0d) that assist with calling the correct C function given a templated scalar value type.