### PR TITLE
Add triangle and diagonal specifiers based on `std::linalg`

### DIFF
--- a/include/spblas/detail/triangular_types.hpp
+++ b/include/spblas/detail/triangular_types.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+namespace spblas {
+
+struct upper_triangle_t {
+  explicit upper_triangle_t() = default;
+};
+inline constexpr upper_triangle_t upper_triangle{};
+
+struct lower_triangle_t {
+  explicit lower_triangle_t() = default;
+};
+inline constexpr lower_triangle_t lower_triangle{};
+
+struct implicit_unit_diagonal_t {
+  explicit implicit_unit_diagonal_t() = default;
+};
+inline constexpr implicit_unit_diagonal_t implicit_unit_diagonal{};
+
+struct explicit_diagonal_t {
+  explicit explicit_diagonal_t() = default;
+};
+inline constexpr explicit_diagonal_t explicit_diagonal{};
+
+} // namespace spblas


### PR DESCRIPTION
Add specifiers triangle and diagonal specifiers for triangular operations.  These are directly based on the tag classes from `std::linalg` [[link](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p1673r13.html#tag-classes-linalg.tags)].

Implementations should statically inspect the types of the triangle and diagonal tags in a manner similar to the following example ([again directly borrowed from `std::linalg`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p1673r13.html#general-linalg.general)):

```cpp
template<class Triangle>
void triangular_matrix_vector_2x2_product(
       mdspan<const float, extents<int, 2, 2>> m,
       Triangle t,
       mdspan<const float, extents<int, 2>> x,
       mdspan<float, extents<int, 2>> y) {

  static_assert(is_same_v<Triangle, lower_triangle_t> ||
                is_same_v<Triangle, upper_triangle_t>);

  if constexpr (is_same_v<Triangle, lower_triangle_t>) {
    y[0] = m[0,0] * x[0]; // + 0 * x[1]
    y[1] = m[1,0] * x[0] + m[1,1] * x[1];
  } else { // upper_triangle_t
    y[0] = m[0,0] * x[0] + m[0,1] * x[1];
    y[1] = /* 0 * x[0] + */ m[1,1] * x[1];
  }
}
```