### PR TITLE
[Intel LLVM][FMT][Bug]Update FMTlib version to 11.1.3 so that Intel Compilers can succeed in building it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
   FetchContent_Declare(
     fmt
     GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-    GIT_TAG 10.1.1)
+    GIT_TAG 11.1.3)
   FetchContent_MakeAvailable(fmt)
 
   add_subdirectory(examples)


### PR DESCRIPTION
Intel COmpiler failed to build FMTLib 10.1.1 due to some bugs:

```
[ 11%] Building CXX object _deps/fmt-build/CMakeFiles/fmt.dir/src/format.cc.o
In file included from /export/users/spatty/spblas-reference/build/_deps/fmt-src/src/format.cc:8:
In file included from /export/users/spatty/spblas-reference/build/_deps/fmt-src/include/fmt/format-inl.h:25:
/export/users/spatty/spblas-reference/build/_deps/fmt-src/include/fmt/format.h:4429:27: warning: identifier '_a' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
 4429 | constexpr auto operator"" _a(const char* s, size_t) -> detail::udl_arg<char> {
      |                ~~~~~~~~~~~^~
      |                operator""_a
In file included from /export/users/spatty/spblas-reference/build/_deps/fmt-src/src/format.cc:8:
/export/users/spatty/spblas-reference/build/_deps/fmt-src/include/fmt/format-inl.h:61:19: error: call to consteval function 'fmt::basic_format_string<char, fmt::basic_string_view<char> &, const char (&)[3]>::basic_format_string<FMT_COMPILE_STRING, 0>' is not a constant expression
   61 |     format_to(it, FMT_STRING("{}{}"), message, SEP);
      |                   ^
/export/users/spatty/spblas-reference/build/_deps/fmt-src/include/fmt/format.h:1905:23: note: expanded from macro 'FMT_STRING'
 1905 | #define FMT_STRING(s) FMT_STRING_IMPL(s, fmt::detail::compile_string, )
      |                       ^
/export/users/spatty/spblas-reference/build/_deps/fmt-src/include/fmt/format.h:1882:3: note: expanded from macro 'FMT_STRING_IMPL'
 1882 |   [] {                                                                        \
      |   ^
/export/users/spatty/spblas-reference/build/_deps/fmt-src/include/fmt/core.h:686:54: note: subexpression not valid in a constant expression
  686 |     format_str_.remove_prefix(detail::to_unsigned(it - begin()));
      |                                                   ~~~^~~~~~~~~
/export/users/spatty/spblas-reference/build/_deps/fmt-src/include/fmt/core.h:2637:5: note: in call to 'this->context_.advance_to(&"{}{}"[1])'
 2637 |     context_.advance_to(begin);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~
/export/users/spatty/spblas-reference/build/_deps/fmt-src/include/fmt/core.h:2632:5: note: in call to 'this->on_format_specs(0, &"{}{}"[1], &"{}{}"[1])'
 2632 |     on_format_specs(id, begin, begin);  // Call parse() on empty specs.
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/export/users/spatty/spblas-reference/build/_deps/fmt-src/include/fmt/core.h:2457:5: note: in call to 'handler.on_replacement_field(0, &"{}{}"[1])'
 2457 |     handler.on_replacement_field(handler.on_arg_id(), begin);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/export/users/spatty/spblas-reference/build/_deps/fmt-src/include/fmt/core.h:2489:21: note: in call to 'parse_replacement_field<char, fmt::detail::format_string_checker<char, fmt::basic_string_view<char>, char[3]> &>(&"{}{}"[1], &"{}{}"[4], checker(s))'
 2489 |         begin = p = parse_replacement_field(p - 1, end, handler);
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/export/users/spatty/spblas-reference/build/_deps/fmt-src/include/fmt/core.h:2740:7: note: in call to 'parse_format_string<true, char, fmt::detail::format_string_checker<char, fmt::basic_string_view<char>, char[3]>>({&"{}{}"[0], 4}, checker(s))'
 2740 |       detail::parse_format_string<true>(str_, checker(s));
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/export/users/spatty/spblas-reference/build/_deps/fmt-src/include/fmt/format-inl.h:61:19: note: in call to 'basic_format_string<FMT_COMPILE_STRING, 0>([] {
    struct __attribute__((visibility("hidden")))  FMT_COMPILE_STRING : fmt::detail::compile_string {
        using char_type [[maybe_unused]] = fmt::remove_cvref_t<decltype("{}{}"[0])>;
        [[maybe_unused]] constexpr operator fmt::basic_string_view<char_type>() const {
            return fmt::detail_exported::compile_string_to_view<char_type>("{}{}");
        }
    };
    return FMT_COMPILE_STRING();
}())'
   61 |     format_to(it, FMT_STRING("{}{}"), message, SEP);
      |                   ^~~~~~~~~~~~~~~~~~

```


After change, it succeeds:

```
[ 11%] Building CXX object _deps/fmt-build/CMakeFiles/fmt.dir/src/format.cc.o
[ 22%] Building CXX object _deps/fmt-build/CMakeFiles/fmt.dir/src/os.cc.o
[ 33%] Linking CXX static library libfmt.a
[ 33%] Built target fmt
[ 44%] Building CXX object examples/CMakeFiles/simple_spmv.dir/simple_spmv.cpp.o
[ 55%] Linking CXX executable simple_spmv
[ 55%] Built target simple_spmv
[ 66%] Building CXX object examples/CMakeFiles/simple_spmm.dir/simple_spmm.cpp.o
[ 77%] Linking CXX executable simple_spmm
[ 77%] Built target simple_spmm
[ 88%] Building CXX object examples/CMakeFiles/simple_spgemm.dir/simple_spgemm.cpp.o
[100%] Linking CXX executable simple_spgemm
[100%] Built target simple_spgemm
```
