### PR TITLE
Add MacOS CI for reference implementation.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,8 +71,12 @@ jobs:
         source /opt/intel/oneapi/setvars.sh
         ./build/test/gtest/spblas-tests
 
-  armpl:
+  macos:
     runs-on: 'macos-latest'
+    strategy:
+      matrix:
+        armpl: [OFF, ON]
+    name: macos${{ matrix.armpl == 'ON' && '-armpl' || '' }}
     steps:
     - uses: actions/checkout@v4
     - name: Set up ArmPL
@@ -82,7 +86,7 @@ jobs:
         echo "ARMPL_DIR=$ARMPL_PATH" >> $GITHUB_ENV
     - name: CMake
       run: |
-        cmake -B build -DENABLE_ARMPL=ON
+        cmake -B build -DENABLE_ARMPL=${{ matrix.armpl }}
     - name: Build
       run: |
         make -C build -j 3

--- a/include/spblas/vendor/armpl/multiply_impl.hpp
+++ b/include/spblas/vendor/armpl/multiply_impl.hpp
@@ -144,7 +144,6 @@ void multiply_fill(operation_info_t& info, A&& a, B&& b, C&& c) {
   std::copy(colind, colind + nnz, c.colind().begin());
   std::copy(rowptr, rowptr + m + 1, c.rowptr().begin());
 
-  // Trigger CI run
   *(c.values().begin()) = 12;
 
   free(values);

--- a/include/spblas/vendor/armpl/multiply_impl.hpp
+++ b/include/spblas/vendor/armpl/multiply_impl.hpp
@@ -144,8 +144,6 @@ void multiply_fill(operation_info_t& info, A&& a, B&& b, C&& c) {
   std::copy(colind, colind + nnz, c.colind().begin());
   std::copy(rowptr, rowptr + m + 1, c.rowptr().begin());
 
-  *(c.values().begin()) = 12;
-
   free(values);
   free(rowptr);
   free(colind);

--- a/include/spblas/vendor/armpl/multiply_impl.hpp
+++ b/include/spblas/vendor/armpl/multiply_impl.hpp
@@ -144,6 +144,7 @@ void multiply_fill(operation_info_t& info, A&& a, B&& b, C&& c) {
   std::copy(colind, colind + nnz, c.colind().begin());
   std::copy(rowptr, rowptr + m + 1, c.rowptr().begin());
 
+  // Trigger CI run
   *(c.values().begin()) = 12;
 
   free(values);

--- a/include/spblas/vendor/armpl/multiply_impl.hpp
+++ b/include/spblas/vendor/armpl/multiply_impl.hpp
@@ -144,6 +144,8 @@ void multiply_fill(operation_info_t& info, A&& a, B&& b, C&& c) {
   std::copy(colind, colind + nnz, c.colind().begin());
   std::copy(rowptr, rowptr + m + 1, c.rowptr().begin());
 
+  *(c.values().begin()) = 12;
+
   free(values);
   free(rowptr);
   free(colind);


### PR DESCRIPTION
This PR adds test coverage for MacOS using the reference implementation.  I imagine a lot of prospective users will be using MacOS, so it's important to check that this doesn't break.

It also appears that GitHub doesn't have a limit on GitHub actions for public repositories, so I don't think we need to worry about using too much CI time.