### PR TITLE
Add CI job that will run on ICL resources.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,3 +93,15 @@ jobs:
     - name: Test
       run: |
         ./build/test/gtest/spblas-tests
+
+  amd-gpu:
+    runs-on: 'gpu_amd'
+    - name: CMake
+      run: |
+        cmake -B build
+    - name: Build
+      run: |
+        make -C build -j `nproc`
+    - name: Test
+      run: |
+        ./build/test/gtest/spblas-tests


### PR DESCRIPTION
This PR aims to add ICL resources to the CI, which will be used for testing GPU vendor backends.