### PR TITLE
Testing CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,3 +93,19 @@ jobs:
     - name: Test
       run: |
         ./build/test/gtest/spblas-tests
+
+  gpu_amd:
+    runs-on: 'gpu_amd'
+    steps:
+    - uses: actions/checkout@v4
+    - name: CMake
+      run: |
+        ls /opt
+        cmake -B build
+    - name: Build
+      run: |
+        make -C build -j `nproc`
+    - name: Test
+      run: |
+        ./build/test/gtest/spblas-tests
+


### PR DESCRIPTION
Please authorize this PR to execute CI jobs for the purposes of testing the remove CI runner.