### PR TITLE
Add a default pull request template for future PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+**Summary:**
+    Short summary of key additions or changes or fixes, including public facing issue
+    or bug being address if it exists
+
+**Details:**
+    
+ - list of key changes to aide present and future reviewers in understanding what
+ - is happening in this PR
+
+**Merge Checklist:**
+
+ - [ ] Passing CI
+ - [ ] Update documentation or README.md
+ - [ ] Additional Test/example added (if applicable) and passing
+ - [ ] At least one reviewer approval
+ - [ ] Clang sanitizer scan run and triaged
+ - [ ] Clang formatter applied

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@
     or bug being address if it exists
 
 **Details:**
-    
+
  - list of key changes to aide present and future reviewers in understanding what
  - is happening in this PR
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,4 +14,4 @@
  - [ ] Additional Test/example added (if applicable) and passing
  - [ ] At least one reviewer approval
  - [ ] (optional) Clang sanitizer scan run and triaged
- - [ ] Clang formatter applied
+ - [ ] Clang formatter applied (verified as part of passing CI)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,5 +13,5 @@
  - [ ] Update documentation or README.md
  - [ ] Additional Test/example added (if applicable) and passing
  - [ ] At least one reviewer approval
- - [ ] Clang sanitizer scan run and triaged
+ - [ ] (optional) Clang sanitizer scan run and triaged
  - [ ] Clang formatter applied


### PR DESCRIPTION
**Summary:**

 Adds default template for PRs, stored in .github/pull_request_template.md

**Details:**

- Each PR created will have this template as their top comment, which gives some guidance for what might be necessary to check.
- See https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository for details

