### PR TITLE
[ONEMKL_SYCL][REF] Add operation_info_t and matrix_opt to more cases and add two examples to cover it

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -11,7 +11,7 @@ if (SPBLAS_CPU_BACKEND)
   add_example(simple_sptrsv)
   add_example(spmm_csc)
   add_example(matrix_opt_example)
-  if (ENABLE_ONEMKL_SYCL OR SPBLAS_REFERENCE_BACKEND )
+  if (ENABLE_ONEMKL_SYCL OR SPBLAS_REFERENCE_BACKEND)
     # needs CPU + matrix_opt + operation_info_t to run
     add_example(sptrsv_csr) # needs triangular_solve{_inspect} to run
     add_example(spmm_csr) # needs multiply{_inspect} to run

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -11,6 +11,11 @@ if (SPBLAS_CPU_BACKEND)
   add_example(simple_sptrsv)
   add_example(spmm_csc)
   add_example(matrix_opt_example)
+  if (ENABLE_ONEMKL_SYCL OR SPBLAS_REFERENCE_BACKEND ) 
+    # needs CPU + matrix_opt + operation_info_t to run
+    add_example(sptrsv_csr) # needs triangular_solve{_inspect} to run
+    add_example(spmm_csr) # needs multiply{_inspect} to run
+  endif()
 endif()
 
 # GPU examples

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -11,7 +11,7 @@ if (SPBLAS_CPU_BACKEND)
   add_example(simple_sptrsv)
   add_example(spmm_csc)
   add_example(matrix_opt_example)
-  if (ENABLE_ONEMKL_SYCL OR SPBLAS_REFERENCE_BACKEND ) 
+  if (ENABLE_ONEMKL_SYCL OR SPBLAS_REFERENCE_BACKEND )
     # needs CPU + matrix_opt + operation_info_t to run
     add_example(sptrsv_csr) # needs triangular_solve{_inspect} to run
     add_example(spmm_csr) # needs multiply{_inspect} to run

--- a/examples/spmm_csr.cpp
+++ b/examples/spmm_csr.cpp
@@ -18,7 +18,6 @@ int main(int argc, char** argv) {
              "######################");
   fmt::print("\n\t### Running Advanced SpMM Example:");
   fmt::print("\n\t###");
-  fmt::print("\n\t###   Y = alpha * A * X");
   fmt::print("\n\t###");
   fmt::print("\n\t### with ");
   fmt::print("\n\t### A, in CSR format, of size ({}, {}) with nnz = {}", m, k,

--- a/examples/spmm_csr.cpp
+++ b/examples/spmm_csr.cpp
@@ -1,0 +1,55 @@
+#include <spblas/spblas.hpp>
+
+#include <fmt/core.h>
+#include <fmt/ranges.h>
+
+int main(int argc, char** argv) {
+  using namespace spblas;
+  namespace md = spblas::__mdspan;
+
+  using T = float;
+
+  spblas::index_t m = 10;
+  spblas::index_t n = 10;
+  spblas::index_t k = 10;
+  spblas::index_t nnz_in = 20;
+
+  fmt::print("\n\t###########################################################"
+             "######################");
+  fmt::print("\n\t### Running Advanced SpMM Example:");
+  fmt::print("\n\t###");
+  fmt::print("\n\t###   Y = alpha * A * X");
+  fmt::print("\n\t###");
+  fmt::print("\n\t### with ");
+  fmt::print("\n\t### A, in CSR format, of size ({}, {}) with nnz = {}", m, k,
+             nnz_in);
+  fmt::print("\n\t### x, a dense matrix, of size ({}, {})", k, n);
+  fmt::print("\n\t### y, a dense vector, of size ({}, {})", m, n);
+  fmt::print("\n\t### using float and spblas::index_t (size = {} bytes)",
+             sizeof(spblas::index_t));
+  fmt::print("\n\t###########################################################"
+             "######################");
+  fmt::print("\n");
+
+  auto&& [values, rowptr, colind, shape, nnz] = generate_csr<T>(m, k, nnz_in);
+
+  csr_view<T> a(values, rowptr, colind, shape, nnz);
+  matrix_opt a_opt(a);
+
+  std::vector<T> x_values(k * n, 1);
+  std::vector<T> y_values(m * n, 0);
+
+  md::mdspan x(x_values.data(), k, n);
+  md::mdspan y(y_values.data(), m, n);
+
+
+  // Y = A * X
+  auto state = multiply_inspect(a_opt, x, y);
+  multiply(state, a_opt, x, y);
+
+  fmt::print("{}\n", spblas::__backend::values(y));
+
+  fmt::print("\tExample is completed!\n");
+
+  return 0;
+}

--- a/examples/spmm_csr.cpp
+++ b/examples/spmm_csr.cpp
@@ -42,7 +42,6 @@ int main(int argc, char** argv) {
   md::mdspan x(x_values.data(), k, n);
   md::mdspan y(y_values.data(), m, n);
 
-
   // Y = A * X
   auto state = multiply_inspect(a_opt, x, y);
   multiply(state, a_opt, x, y);

--- a/examples/sptrsv_csr.cpp
+++ b/examples/sptrsv_csr.cpp
@@ -1,0 +1,64 @@
+#include <spblas/spblas.hpp>
+
+#include <fmt/core.h>
+#include <fmt/ranges.h>
+
+int main(int argc, char** argv) {
+  using namespace spblas;
+
+  using T = float;
+
+  spblas::index_t m = 100;
+  spblas::index_t nnz_in = 20;
+
+  fmt::print("\n\t###########################################################"
+             "######################");
+  fmt::print("\n\t### Running Full SpTRSV Example:");
+  fmt::print("\n\t###");
+  fmt::print("\n\t###   solve for x:  A * x = alpha * b");
+  fmt::print("\n\t###");
+  fmt::print("\n\t### with ");
+  fmt::print("\n\t### A, in CSR format, of size ({}, {}) with nnz = {}", m, m,
+             nnz_in);
+  fmt::print("\n\t### x, a dense vector, of size ({}, {})", m, 1);
+  fmt::print("\n\t### b, a dense vector, of size ({}, {})", m, 1);
+  fmt::print("\n\t### using float and spblas::index_t (size = {} bytes)",
+             sizeof(spblas::index_t));
+  fmt::print("\n\t###########################################################"
+             "######################");
+  fmt::print("\n");
+
+  auto&& [values, rowptr, colind, shape, nnz] =
+      generate_csr<T, spblas::index_t>(m, m, nnz_in);
+
+  // scale values of matrix to make the implicit unit diagonal matrix
+  // be diagonally dominant, so it is solveable
+  T scale_factor = 1e-3f;
+  std::transform(values.begin(), values.end(), values.begin(),
+                 [scale_factor](T val) { return scale_factor * val; });
+
+  csr_view<T, spblas::index_t> a(values, rowptr, colind, shape, nnz);
+
+  matrix_opt a_opt(a);
+
+  // Scale every value of `a` by 5 in place.
+  // scale(5.f, a);
+
+  std::vector<T> x(m, 0);
+  std::vector<T> b(m, 1);
+
+  T alpha = 1.2f;
+  auto b_scaled = scaled(alpha, b);
+
+  // solve for x:  lower(A) * x = alpha * b
+  triangular_solve_inspect(a_opt, spblas::upper_triangle_t{},
+                           spblas::implicit_unit_diagonal_t{}, b_scaled, x);
+
+  triangular_solve(a_opt, spblas::upper_triangle_t{},
+                   spblas::implicit_unit_diagonal_t{}, b_scaled, x);
+
+
+  fmt::print("\tExample is completed!\n");
+
+  return 0;
+}

--- a/examples/sptrsv_csr.cpp
+++ b/examples/sptrsv_csr.cpp
@@ -57,7 +57,6 @@ int main(int argc, char** argv) {
   triangular_solve(a_opt, spblas::upper_triangle_t{},
                    spblas::implicit_unit_diagonal_t{}, b_scaled, x);
 
-
   fmt::print("\tExample is completed!\n");
 
   return 0;

--- a/include/spblas/algorithms/multiply.hpp
+++ b/include/spblas/algorithms/multiply.hpp
@@ -18,7 +18,6 @@ void multiply(A&& a, B&& b, C&& c);
 template <matrix A, vector B, vector C>
 void multiply(operation_into_t& info, A&& a, B&& b, C&& c);
 
-
 // SpMM variants
 template <matrix A, matrix B, matrix C>
 void multiply(A&& a, B&& b, C&& c);
@@ -33,16 +32,18 @@ operation_info_t multiply_inspect(A&& a, B&& b, C&& c);
 template <matrix A, matrix B, matrix C>
 void multiply_inspect(operation_info_t& info, A&& a, B&& b, C&& c);
 
-
 // SpGEMM variants
 template <typename ExecutionPolicy, matrix A, matrix B, matrix C>
-operation_info_t multiply_compute(ExecutionPolicy &&policy, A&& a, B&& b, C&& c);
+operation_info_t multiply_compute(ExecutionPolicy&& policy, A&& a, B&& b,
+                                  C&& c);
 
 template <typename ExecutionPolicy, matrix A, matrix B, matrix C>
-void multiply_compute(ExecutionPolicy &&policy, operation_info_t& info, A&& a, B&& b, C&& c);
+void multiply_compute(ExecutionPolicy&& policy, operation_info_t& info, A&& a,
+                      B&& b, C&& c);
 
 template <typename ExecutionPolicy, matrix A, matrix B, matrix C>
-void multiply_fill(ExecutionPolicy &&policy, operation_info_t& info, A&& a, B&& b, C&& c);
+void multiply_fill(ExecutionPolicy&& policy, operation_info_t& info, A&& a,
+                   B&& b, C&& c);
 
 template <matrix A, matrix B, matrix C>
 operation_info_t multiply_compute(A&& a, B&& b, C&& c);

--- a/include/spblas/algorithms/multiply.hpp
+++ b/include/spblas/algorithms/multiply.hpp
@@ -5,17 +5,44 @@
 
 namespace spblas {
 
+// SpMV variants
+template <matrix A, vector B, vector C>
+operation_info_t multiply_inspect(A&& a, B&& b, C&& c);
+
+template <matrix A, vector B, vector C>
+void multiply_inspect(operation_info_t& info, A&& a, B&& b, C&& c);
+
 template <matrix A, vector B, vector C>
 void multiply(A&& a, B&& b, C&& c);
 
+template <matrix A, vector B, vector C>
+void multiply(operation_into_t& info, A&& a, B&& b, C&& c);
+
+
+// SpMM variants
 template <matrix A, matrix B, matrix C>
 void multiply(A&& a, B&& b, C&& c);
 
+template <matrix A, matrix B, matrix C>
+void multiply(operation_info_t& info, A&& a, B&& b, C&& c);
+
+// SpMM and SpGEMM multiply_inspect variants
 template <matrix A, matrix B, matrix C>
 operation_info_t multiply_inspect(A&& a, B&& b, C&& c);
 
 template <matrix A, matrix B, matrix C>
 void multiply_inspect(operation_info_t& info, A&& a, B&& b, C&& c);
+
+
+// SpGEMM variants
+template <typename ExecutionPolicy, matrix A, matrix B, matrix C>
+operation_info_t multiply_compute(ExecutionPolicy &&policy, A&& a, B&& b, C&& c);
+
+template <typename ExecutionPolicy, matrix A, matrix B, matrix C>
+void multiply_compute(ExecutionPolicy &&policy, operation_info_t& info, A&& a, B&& b, C&& c);
+
+template <typename ExecutionPolicy, matrix A, matrix B, matrix C>
+void multiply_fill(ExecutionPolicy &&policy, operation_info_t& info, A&& a, B&& b, C&& c);
 
 template <matrix A, matrix B, matrix C>
 operation_info_t multiply_compute(A&& a, B&& b, C&& c);

--- a/include/spblas/algorithms/multiply_impl.hpp
+++ b/include/spblas/algorithms/multiply_impl.hpp
@@ -85,7 +85,7 @@ void multiply(A&& a, B&& b, C&& c) {
   __backend::for_each(a, [&](auto&& e) {
     auto&& [idx, a_v] = e;
     auto&& [i, k] = idx;
-    for (std::size_t j = 0; j < __backend::shape(b)[1]; j++) { // b_row
+    for (std::size_t j = 0; j < __backend::shape(b)[1]; j++) {
       __backend::lookup(c, i, j) += a_v * __backend::lookup(b, k, j);
     }
   });

--- a/include/spblas/algorithms/multiply_impl.hpp
+++ b/include/spblas/algorithms/multiply_impl.hpp
@@ -56,11 +56,10 @@ void multiply(A&& a, B&& b, C&& c) {
 // SpMV with info input
 template <matrix A, vector B, vector C>
   requires(__backend::lookupable<B> && __backend::lookupable<C>)
-void multiply(operation_info_t &info, A&& a, B&& b, C&& c) {
+void multiply(operation_info_t& info, A&& a, B&& b, C&& c) {
   log_trace("");
   multiply(std::forward<A>(a), std::forward<B>(b), std::forward<C>(c));
 }
-
 
 // C = AB
 // SpMM
@@ -81,7 +80,7 @@ void multiply(A&& a, B&& b, C&& c) {
     v = 0;
   });
 
-  // traverses elements of a and performs appropriate 
+  // traverses elements of a and performs appropriate
   // multiplication with B rows
   __backend::for_each(a, [&](auto&& e) {
     auto&& [idx, a_v] = e;
@@ -96,11 +95,10 @@ void multiply(A&& a, B&& b, C&& c) {
 // SpMM with info
 template <matrix A, matrix B, matrix C>
   requires(__backend::lookupable<B> && __backend::lookupable<C>)
-void multiply(operation_info_t &info, A&& a, B&& b, C&& c) {
+void multiply(operation_info_t& info, A&& a, B&& b, C&& c) {
   log_trace("");
   multiply(std::forward<A>(a), std::forward<B>(b), std::forward<C>(c));
 }
-
 
 // C = AB
 // SpMM or SpGEMM multiply_inspect variants end up here
@@ -113,10 +111,9 @@ operation_info_t multiply_inspect(A&& a, B&& b, C&& c) {
 // C = AB
 // SpMM or SpGEMM multiply_inspect variants end up here
 template <matrix A, matrix B, matrix C>
-void multiply_inspect(operation_info_t& info, A&& a, B&& b, C&& c){
+void multiply_inspect(operation_info_t& info, A&& a, B&& b, C&& c) {
   log_trace("");
 };
-
 
 // C = AB
 // SpGEMM compute stage with CSR output

--- a/include/spblas/algorithms/multiply_impl.hpp
+++ b/include/spblas/algorithms/multiply_impl.hpp
@@ -15,6 +15,19 @@
 
 namespace spblas {
 
+// SpMV inspect
+template <matrix A, vector B, vector C>
+operation_info_t multiply_inspect(A&& a, B&& b, C&& c) {
+  log_trace("");
+  return operation_info_t{};
+}
+
+// SpMV inspect
+template <matrix A, vector B, vector C>
+operation_info_t multiply_inspect(operation_info_t& info, A&& a, B&& b, C&& c) {
+  log_trace("");
+}
+
 // C = AB
 // SpMV
 template <matrix A, vector B, vector C>
@@ -40,6 +53,16 @@ void multiply(A&& a, B&& b, C&& c) {
 }
 
 // C = AB
+// SpMV with info input
+template <matrix A, vector B, vector C>
+  requires(__backend::lookupable<B> && __backend::lookupable<C>)
+void multiply(operation_info_t &info, A&& a, B&& b, C&& c) {
+  log_trace("");
+  multiply(std::forward<A>(a), std::forward<B>(b), std::forward<C>(c));
+}
+
+
+// C = AB
 // SpMM
 template <matrix A, matrix B, matrix C>
   requires(__backend::lookupable<B> && __backend::lookupable<C>)
@@ -52,37 +75,63 @@ void multiply(A&& a, B&& b, C&& c) {
         "multiply: matrix dimensions are incompatible.");
   }
 
+  // initializes c to zero so we can use += everywhere
   __backend::for_each(c, [](auto&& e) {
     auto&& [_, v] = e;
     v = 0;
   });
 
+  // traverses elements of a and performs appropriate 
+  // multiplication with B rows
   __backend::for_each(a, [&](auto&& e) {
     auto&& [idx, a_v] = e;
     auto&& [i, k] = idx;
-    for (std::size_t j = 0; j < __backend::shape(b)[1]; j++) {
+    for (std::size_t j = 0; j < __backend::shape(b)[1]; j++) { // b_row
       __backend::lookup(c, i, j) += a_v * __backend::lookup(b, k, j);
     }
   });
 }
 
+// C = AB
+// SpMM with info
+template <matrix A, matrix B, matrix C>
+  requires(__backend::lookupable<B> && __backend::lookupable<C>)
+void multiply(operation_info_t &info, A&& a, B&& b, C&& c) {
+  log_trace("");
+  multiply(std::forward<A>(a), std::forward<B>(b), std::forward<C>(c));
+}
+
+
+// C = AB
+// SpMM or SpGEMM multiply_inspect variants end up here
 template <matrix A, matrix B, matrix C>
 operation_info_t multiply_inspect(A&& a, B&& b, C&& c) {
+  log_trace("");
   return operation_info_t{};
 }
 
+// C = AB
+// SpMM or SpGEMM multiply_inspect variants end up here
 template <matrix A, matrix B, matrix C>
-void multiply_inspect(operation_info_t& info, A&& a, B&& b, C&& c){};
+void multiply_inspect(operation_info_t& info, A&& a, B&& b, C&& c){
+  log_trace("");
+};
 
+
+// C = AB
+// SpGEMM compute stage with CSR output
 template <matrix A, matrix B, matrix C>
   requires(__backend::row_iterable<A> && __backend::row_iterable<B> &&
            __detail::is_csr_view_v<C>)
 void multiply_compute(operation_info_t& info, A&& a, B&& b, C&& c) {
+  log_trace("");
   auto new_info = multiply_compute(std::forward<A>(a), std::forward<B>(b),
                                    std::forward<C>(c));
   info.update_impl_(new_info.result_shape(), new_info.result_nnz());
 }
 
+// C = AB
+// SpGEMM compute stage with CSC output
 template <matrix A, matrix B, matrix C>
   requires(__backend::column_iterable<A> && __backend::column_iterable<B> &&
            __detail::is_csc_view_v<C>)
@@ -93,6 +142,7 @@ void multiply_compute(operation_info_t& info, A&& a, B&& b, C&& c) {
 }
 
 // C = AB
+// SpGEMM fill stage with CSR or CSC output
 template <matrix A, matrix B, matrix C>
 void multiply_fill(operation_info_t info, A&& a, B&& b, C&& c) {
   log_trace("");

--- a/include/spblas/algorithms/triangular_solve.hpp
+++ b/include/spblas/algorithms/triangular_solve.hpp
@@ -3,12 +3,16 @@
 #include <spblas/concepts.hpp>
 #include <spblas/detail/operation_info_t.hpp>
 
-template <class ExecutionPolicy, in - matrix InMat, class Triangle,
-          class DiagonalStorage, in - vector InVec, out - vector OutVec>
-void triangular_matrix_vector_solve(ExecutionPolicy&& exec, InMat A, Triangle t,
-                                    DiagonalStorage d, InVec b, OutVec x);
-
 namespace spblas {
+
+
+template <matrix A, class Triangle, class DiagonalStorage, vector B, vector X>
+void triangular_solve_inspect(operation_info_t& info, A&& a, Triangle uplo, DiagonalStorage diag, B&& b, X&& x);
+
+
+template <matrix A, class Triangle, class DiagonalStorage, vector B, vector X>
+operation_info_t triangular_solve_inspect(A&& a, Triangle uplo, DiagonalStorage diag, B&& b, X&& x);
+
 
 template <matrix A, class Triangle, class DiagonalStorage, vector B, vector X>
 void triangular_solve(A&& a, Triangle uplo, DiagonalStorage diag, B&& b, X&& x);

--- a/include/spblas/algorithms/triangular_solve.hpp
+++ b/include/spblas/algorithms/triangular_solve.hpp
@@ -5,14 +5,13 @@
 
 namespace spblas {
 
+template <matrix A, class Triangle, class DiagonalStorage, vector B, vector X>
+void triangular_solve_inspect(operation_info_t& info, A&& a, Triangle uplo,
+                              DiagonalStorage diag, B&& b, X&& x);
 
 template <matrix A, class Triangle, class DiagonalStorage, vector B, vector X>
-void triangular_solve_inspect(operation_info_t& info, A&& a, Triangle uplo, DiagonalStorage diag, B&& b, X&& x);
-
-
-template <matrix A, class Triangle, class DiagonalStorage, vector B, vector X>
-operation_info_t triangular_solve_inspect(A&& a, Triangle uplo, DiagonalStorage diag, B&& b, X&& x);
-
+operation_info_t triangular_solve_inspect(A&& a, Triangle uplo,
+                                          DiagonalStorage diag, B&& b, X&& x);
 
 template <matrix A, class Triangle, class DiagonalStorage, vector B, vector X>
 void triangular_solve(A&& a, Triangle uplo, DiagonalStorage diag, B&& b, X&& x);

--- a/include/spblas/algorithms/triangular_solve_impl.hpp
+++ b/include/spblas/algorithms/triangular_solve_impl.hpp
@@ -8,10 +8,39 @@
 
 namespace spblas {
 
+// X = inv(A) B
+// SpTRSV inspect stage
+template <matrix A, class Triangle, class DiagonalStorage, vector B, vector X>
+  requires(__backend::row_iterable<A> && __backend::lookupable<B> &&
+           __backend::lookupable<X>)
+operation_info_t triangular_solve_inspect(A&& a, Triangle t, DiagonalStorage d, B&& b, X&& x) {
+  log_trace("");
+  static_assert(std::is_same_v<Triangle, upper_triangle_t> ||
+                std::is_same_v<Triangle, lower_triangle_t>);
+  assert(__backend::shape(a)[0] == __backend::shape(a)[1]);
+
+  return operation_info_t{};
+}
+
+// X = inv(A) B
+// SpTRSV inspect stage
+template <matrix A, class Triangle, class DiagonalStorage, vector B, vector X>
+  requires(__backend::row_iterable<A> && __backend::lookupable<B> &&
+           __backend::lookupable<X>)
+void triangular_solve_inspect(operation_info_t& info, A&& a, Triangle t, DiagonalStorage d, B&& b, X&& x) {
+  log_trace("");
+  static_assert(std::is_same_v<Triangle, upper_triangle_t> ||
+                std::is_same_v<Triangle, lower_triangle_t>);
+  assert(__backend::shape(a)[0] == __backend::shape(a)[1]);
+}
+
+// X = inv(A) B
+// SpTRSV solve stage
 template <matrix A, class Triangle, class DiagonalStorage, vector B, vector X>
   requires(__backend::row_iterable<A> && __backend::lookupable<B> &&
            __backend::lookupable<X>)
 void triangular_solve(A&& a, Triangle t, DiagonalStorage d, B&& b, X&& x) {
+  log_trace("");
   static_assert(std::is_same_v<Triangle, upper_triangle_t> ||
                 std::is_same_v<Triangle, lower_triangle_t>);
   assert(__backend::shape(a)[0] == __backend::shape(a)[1]);
@@ -61,5 +90,16 @@ void triangular_solve(A&& a, Triangle t, DiagonalStorage d, B&& b, X&& x) {
     }
   }
 }
+
+// X = inv(A) B
+// SpTRSV solve stage with info
+template <matrix A, class Triangle, class DiagonalStorage, vector B, vector X>
+  requires(__backend::row_iterable<A> && __backend::lookupable<B> &&
+           __backend::lookupable<X>)
+void triangular_solve(operation_info_t& info, A&& a, Triangle t, DiagonalStorage d, B&& b, X&& x) {
+  log_trace("");
+  triangular_solve(std::forward<A>(a), std::forward<Triangle>(t), std::forward<DiagonalStorage>(d), std::forward<B>(b), std::forward<X>(x));
+}
+
 
 } // namespace spblas

--- a/include/spblas/algorithms/triangular_solve_impl.hpp
+++ b/include/spblas/algorithms/triangular_solve_impl.hpp
@@ -13,7 +13,8 @@ namespace spblas {
 template <matrix A, class Triangle, class DiagonalStorage, vector B, vector X>
   requires(__backend::row_iterable<A> && __backend::lookupable<B> &&
            __backend::lookupable<X>)
-operation_info_t triangular_solve_inspect(A&& a, Triangle t, DiagonalStorage d, B&& b, X&& x) {
+operation_info_t triangular_solve_inspect(A&& a, Triangle t, DiagonalStorage d,
+                                          B&& b, X&& x) {
   log_trace("");
   static_assert(std::is_same_v<Triangle, upper_triangle_t> ||
                 std::is_same_v<Triangle, lower_triangle_t>);
@@ -27,7 +28,8 @@ operation_info_t triangular_solve_inspect(A&& a, Triangle t, DiagonalStorage d, 
 template <matrix A, class Triangle, class DiagonalStorage, vector B, vector X>
   requires(__backend::row_iterable<A> && __backend::lookupable<B> &&
            __backend::lookupable<X>)
-void triangular_solve_inspect(operation_info_t& info, A&& a, Triangle t, DiagonalStorage d, B&& b, X&& x) {
+void triangular_solve_inspect(operation_info_t& info, A&& a, Triangle t,
+                              DiagonalStorage d, B&& b, X&& x) {
   log_trace("");
   static_assert(std::is_same_v<Triangle, upper_triangle_t> ||
                 std::is_same_v<Triangle, lower_triangle_t>);
@@ -96,10 +98,12 @@ void triangular_solve(A&& a, Triangle t, DiagonalStorage d, B&& b, X&& x) {
 template <matrix A, class Triangle, class DiagonalStorage, vector B, vector X>
   requires(__backend::row_iterable<A> && __backend::lookupable<B> &&
            __backend::lookupable<X>)
-void triangular_solve(operation_info_t& info, A&& a, Triangle t, DiagonalStorage d, B&& b, X&& x) {
+void triangular_solve(operation_info_t& info, A&& a, Triangle t,
+                      DiagonalStorage d, B&& b, X&& x) {
   log_trace("");
-  triangular_solve(std::forward<A>(a), std::forward<Triangle>(t), std::forward<DiagonalStorage>(d), std::forward<B>(b), std::forward<X>(x));
+  triangular_solve(std::forward<A>(a), std::forward<Triangle>(t),
+                   std::forward<DiagonalStorage>(d), std::forward<B>(b),
+                   std::forward<X>(x));
 }
-
 
 } // namespace spblas

--- a/include/spblas/vendor/onemkl_sycl/detail/create_matrix_handle.hpp
+++ b/include/spblas/vendor/onemkl_sycl/detail/create_matrix_handle.hpp
@@ -17,8 +17,13 @@ oneapi::mkl::sparse::matrix_handle_t create_matrix_handle(sycl::queue& q,
   oneapi::mkl::sparse::matrix_handle_t handle = nullptr;
   oneapi::mkl::sparse::init_matrix_handle(&handle);
 
+
   oneapi::mkl::sparse::set_csr_data(
-      q, handle, m.shape()[0], m.shape()[1], oneapi::mkl::index_base::zero,
+      q, handle, m.shape()[0], m.shape()[1], 
+#if defined(__INTEL_MKL__) && ( (__INTEL_MKL__ == 2025) && (__INTEL_MKL_MINOR__ == 3) || (__INTEL_MKL__ > 2025 ) )
+      m.size(), // nnz added in 2025.3, and without deprecated
+#endif          
+      oneapi::mkl::index_base::zero,
       m.rowptr().data(), m.colind().data(), m.values().data())
       .wait();
 
@@ -33,7 +38,11 @@ oneapi::mkl::sparse::matrix_handle_t create_matrix_handle(sycl::queue& q,
   oneapi::mkl::sparse::init_matrix_handle(&handle);
 
   oneapi::mkl::sparse::set_csr_data(
-      q, handle, m.shape()[1], m.shape()[0], oneapi::mkl::index_base::zero,
+      q, handle, m.shape()[1], m.shape()[0], 
+#if defined(__INTEL_MKL__) && ( (__INTEL_MKL__ == 2025) && (__INTEL_MKL_MINOR__ == 3) || (__INTEL_MKL__ > 2025 ) )
+      m.size(), // nnz added in 2025.3, and without deprecated
+#endif  
+      oneapi::mkl::index_base::zero,
       m.colptr().data(), m.rowind().data(), m.values().data())
       .wait();
 

--- a/include/spblas/vendor/onemkl_sycl/detail/create_matrix_handle.hpp
+++ b/include/spblas/vendor/onemkl_sycl/detail/create_matrix_handle.hpp
@@ -17,14 +17,15 @@ oneapi::mkl::sparse::matrix_handle_t create_matrix_handle(sycl::queue& q,
   oneapi::mkl::sparse::matrix_handle_t handle = nullptr;
   oneapi::mkl::sparse::init_matrix_handle(&handle);
 
-
   oneapi::mkl::sparse::set_csr_data(
-      q, handle, m.shape()[0], m.shape()[1], 
-#if defined(__INTEL_MKL__) && ( (__INTEL_MKL__ == 2025) && (__INTEL_MKL_MINOR__ == 3) || (__INTEL_MKL__ > 2025 ) )
+      q, handle, m.shape()[0], m.shape()[1],
+#if defined(__INTEL_MKL__) &&                                                  \
+    ((__INTEL_MKL__ == 2025) && (__INTEL_MKL_MINOR__ == 3) ||                  \
+     (__INTEL_MKL__ > 2025))
       m.size(), // nnz added in 2025.3, and without deprecated
-#endif          
-      oneapi::mkl::index_base::zero,
-      m.rowptr().data(), m.colind().data(), m.values().data())
+#endif
+      oneapi::mkl::index_base::zero, m.rowptr().data(), m.colind().data(),
+      m.values().data())
       .wait();
 
   return handle;
@@ -38,12 +39,14 @@ oneapi::mkl::sparse::matrix_handle_t create_matrix_handle(sycl::queue& q,
   oneapi::mkl::sparse::init_matrix_handle(&handle);
 
   oneapi::mkl::sparse::set_csr_data(
-      q, handle, m.shape()[1], m.shape()[0], 
-#if defined(__INTEL_MKL__) && ( (__INTEL_MKL__ == 2025) && (__INTEL_MKL_MINOR__ == 3) || (__INTEL_MKL__ > 2025 ) )
+      q, handle, m.shape()[1], m.shape()[0],
+#if defined(__INTEL_MKL__) &&                                                  \
+    ((__INTEL_MKL__ == 2025) && (__INTEL_MKL_MINOR__ == 3) ||                  \
+     (__INTEL_MKL__ > 2025))
       m.size(), // nnz added in 2025.3, and without deprecated
-#endif  
-      oneapi::mkl::index_base::zero,
-      m.colptr().data(), m.rowind().data(), m.values().data())
+#endif
+      oneapi::mkl::index_base::zero, m.colptr().data(), m.rowind().data(),
+      m.values().data())
       .wait();
 
   return handle;

--- a/include/spblas/vendor/onemkl_sycl/spgemm_impl.hpp
+++ b/include/spblas/vendor/onemkl_sycl/spgemm_impl.hpp
@@ -29,6 +29,10 @@
 
 namespace spblas {
 
+
+//
+// multiply_compute -- csr/csc * csr/csc -> csr with ExecutionPolicy
+//
 template <typename ExecutionPolicy, matrix A, matrix B, matrix C>
   requires(__detail::has_csr_base<A> || __detail::has_csc_base<A>) &&
           (__detail::has_csr_base<B> || __detail::has_csc_base<B>) &&
@@ -68,6 +72,9 @@ operation_info_t
 
   oneapi::mkl::sparse::set_csr_data(
       q, c_handle, __backend::shape(c)[0], __backend::shape(c)[1],
+#if defined(__INTEL_MKL__) && ( (__INTEL_MKL__ == 2025) && (__INTEL_MKL_MINOR__ == 3) || (__INTEL_MKL__ > 2025 ) )
+      __backend::size(c), // nnz added in 2025.3, and without deprecated
+#endif  
       oneapi::mkl::index_base::zero, c_rowptr, (I*) nullptr, (T*) nullptr)
       .wait();
 
@@ -117,8 +124,36 @@ operation_info_t
       __mkl::operation_state_t{__detail::has_matrix_opt(a) ? nullptr : a_handle,
                                __detail::has_matrix_opt(b) ? nullptr : b_handle,
                                c_handle, nullptr, descr, (void*) c_rowptr, q}};
-}
+} // multiply_compute
 
+//
+// multiply_compute -- csr/csc * csr/csc -> csr with ExecutionPolicy
+//
+template <typename ExecutionPolicy, matrix A, matrix B, matrix C>
+  requires(__detail::has_csr_base<A> || __detail::has_csc_base<A>) &&
+          (__detail::has_csr_base<B> || __detail::has_csc_base<B>) &&
+          __detail::is_csr_view_v<C>
+void
+    multiply_compute(ExecutionPolicy&& policy, operation_info_t &info, A&& a, B&& b, C&& c) {
+  log_trace("");
+
+  auto tmp_info = multiply_compute(std::forward<ExecutionPolicy>(policy), std::forward<A>(a), std::forward<B>(b), std::forward<C>(c));
+
+  // fill the normal bucket of state stuf based on creating model for now.
+  info.update_impl_(tmp_info.result_shape(), tmp_info.result_nnz());
+  info.state_.a_handle = tmp_info.state_.a_handle;
+  info.state_.b_handle = tmp_info.state_.b_handle;
+  info.state_.c_handle = tmp_info.state_.c_handle;
+  info.state_.descr    = tmp_info.state_.descr;
+  info.state_.c_rowptr = tmp_info.state_.c_rowptr;
+  info.state_.q        = tmp_info.state_.q;
+        
+} // multiply_compute
+
+
+//
+// multiply_fill -- csr/csc * csr/csc -> csr with ExecutionPolicy
+//
 template <typename ExecutionPolicy, matrix A, matrix B, matrix C>
   requires(__detail::has_csr_base<A> || __detail::has_csc_base<A>) &&
           (__detail::has_csr_base<B> || __detail::has_csc_base<B>) &&
@@ -155,6 +190,9 @@ void multiply_fill(ExecutionPolicy&& policy, operation_info_t& info, A&& a,
 
   auto ev_setC = oneapi::mkl::sparse::set_csr_data(
       q, c_handle, __backend::shape(c)[0], __backend::shape(c)[1],
+#if defined(__INTEL_MKL__) && ( (__INTEL_MKL__ == 2025) && (__INTEL_MKL_MINOR__ == 3) || (__INTEL_MKL__ > 2025 ) )
+      __backend::size(c), // nnz added in 2025.3, and without deprecated
+#endif  
       oneapi::mkl::index_base::zero, c_rowptr, c.colind().data(),
       c.values().data());
 
@@ -190,6 +228,15 @@ template <matrix A, matrix B, matrix C>
   requires(__detail::has_csr_base<A> || __detail::has_csc_base<A>) &&
           (__detail::has_csr_base<B> || __detail::has_csc_base<B>) &&
           __detail::is_csr_view_v<C>
+void multiply_compute(operation_info_t & info, A&& a, B&& b, C&& c) {
+  return multiply_compute(mkl::par, std::forward<operation_info_t>(info), std::forward<A>(a), std::forward<B>(b),
+                          std::forward<C>(c));
+}
+
+template <matrix A, matrix B, matrix C>
+  requires(__detail::has_csr_base<A> || __detail::has_csc_base<A>) &&
+          (__detail::has_csr_base<B> || __detail::has_csc_base<B>) &&
+          __detail::is_csr_view_v<C>
 void multiply_fill(operation_info_t& info, A&& a, B&& b, C&& c) {
   multiply_fill(mkl::par, info, std::forward<A>(a), std::forward<B>(b),
                 std::forward<C>(c));
@@ -202,6 +249,7 @@ template <matrix A, matrix B, matrix C>
 operation_info_t multiply_compute(A&& a, B&& b, C&& c) {
   return multiply_compute(transposed(b), transposed(a), transposed(c));
 }
+
 
 template <matrix A, matrix B, matrix C>
   requires((__detail::has_csr_base<A> || __detail::has_csc_base<A>) &&

--- a/include/spblas/vendor/onemkl_sycl/spgemm_impl.hpp
+++ b/include/spblas/vendor/onemkl_sycl/spgemm_impl.hpp
@@ -29,7 +29,6 @@
 
 namespace spblas {
 
-
 //
 // multiply_compute -- csr/csc * csr/csc -> csr with ExecutionPolicy
 //
@@ -72,9 +71,11 @@ operation_info_t
 
   oneapi::mkl::sparse::set_csr_data(
       q, c_handle, __backend::shape(c)[0], __backend::shape(c)[1],
-#if defined(__INTEL_MKL__) && ( (__INTEL_MKL__ == 2025) && (__INTEL_MKL_MINOR__ == 3) || (__INTEL_MKL__ > 2025 ) )
+#if defined(__INTEL_MKL__) &&                                                  \
+    ((__INTEL_MKL__ == 2025) && (__INTEL_MKL_MINOR__ == 3) ||                  \
+     (__INTEL_MKL__ > 2025))
       __backend::size(c), // nnz added in 2025.3, and without deprecated
-#endif  
+#endif
       oneapi::mkl::index_base::zero, c_rowptr, (I*) nullptr, (T*) nullptr)
       .wait();
 
@@ -133,23 +134,24 @@ template <typename ExecutionPolicy, matrix A, matrix B, matrix C>
   requires(__detail::has_csr_base<A> || __detail::has_csc_base<A>) &&
           (__detail::has_csr_base<B> || __detail::has_csc_base<B>) &&
           __detail::is_csr_view_v<C>
-void
-    multiply_compute(ExecutionPolicy&& policy, operation_info_t &info, A&& a, B&& b, C&& c) {
+void multiply_compute(ExecutionPolicy&& policy, operation_info_t& info, A&& a,
+                      B&& b, C&& c) {
   log_trace("");
 
-  auto tmp_info = multiply_compute(std::forward<ExecutionPolicy>(policy), std::forward<A>(a), std::forward<B>(b), std::forward<C>(c));
+  auto tmp_info = multiply_compute(std::forward<ExecutionPolicy>(policy),
+                                   std::forward<A>(a), std::forward<B>(b),
+                                   std::forward<C>(c));
 
   // fill the normal bucket of state stuf based on creating model for now.
   info.update_impl_(tmp_info.result_shape(), tmp_info.result_nnz());
   info.state_.a_handle = tmp_info.state_.a_handle;
   info.state_.b_handle = tmp_info.state_.b_handle;
   info.state_.c_handle = tmp_info.state_.c_handle;
-  info.state_.descr    = tmp_info.state_.descr;
+  info.state_.descr = tmp_info.state_.descr;
   info.state_.c_rowptr = tmp_info.state_.c_rowptr;
-  info.state_.q        = tmp_info.state_.q;
-        
-} // multiply_compute
+  info.state_.q = tmp_info.state_.q;
 
+} // multiply_compute
 
 //
 // multiply_fill -- csr/csc * csr/csc -> csr with ExecutionPolicy
@@ -190,9 +192,11 @@ void multiply_fill(ExecutionPolicy&& policy, operation_info_t& info, A&& a,
 
   auto ev_setC = oneapi::mkl::sparse::set_csr_data(
       q, c_handle, __backend::shape(c)[0], __backend::shape(c)[1],
-#if defined(__INTEL_MKL__) && ( (__INTEL_MKL__ == 2025) && (__INTEL_MKL_MINOR__ == 3) || (__INTEL_MKL__ > 2025 ) )
+#if defined(__INTEL_MKL__) &&                                                  \
+    ((__INTEL_MKL__ == 2025) && (__INTEL_MKL_MINOR__ == 3) ||                  \
+     (__INTEL_MKL__ > 2025))
       __backend::size(c), // nnz added in 2025.3, and without deprecated
-#endif  
+#endif
       oneapi::mkl::index_base::zero, c_rowptr, c.colind().data(),
       c.values().data());
 
@@ -228,8 +232,9 @@ template <matrix A, matrix B, matrix C>
   requires(__detail::has_csr_base<A> || __detail::has_csc_base<A>) &&
           (__detail::has_csr_base<B> || __detail::has_csc_base<B>) &&
           __detail::is_csr_view_v<C>
-void multiply_compute(operation_info_t & info, A&& a, B&& b, C&& c) {
-  return multiply_compute(mkl::par, std::forward<operation_info_t>(info), std::forward<A>(a), std::forward<B>(b),
+void multiply_compute(operation_info_t& info, A&& a, B&& b, C&& c) {
+  return multiply_compute(mkl::par, std::forward<operation_info_t>(info),
+                          std::forward<A>(a), std::forward<B>(b),
                           std::forward<C>(c));
 }
 
@@ -249,7 +254,6 @@ template <matrix A, matrix B, matrix C>
 operation_info_t multiply_compute(A&& a, B&& b, C&& c) {
   return multiply_compute(transposed(b), transposed(a), transposed(c));
 }
-
 
 template <matrix A, matrix B, matrix C>
   requires((__detail::has_csr_base<A> || __detail::has_csc_base<A>) &&

--- a/include/spblas/vendor/onemkl_sycl/spgemm_impl.hpp
+++ b/include/spblas/vendor/onemkl_sycl/spgemm_impl.hpp
@@ -233,6 +233,7 @@ template <matrix A, matrix B, matrix C>
           (__detail::has_csr_base<B> || __detail::has_csc_base<B>) &&
           __detail::is_csr_view_v<C>
 void multiply_compute(operation_info_t& info, A&& a, B&& b, C&& c) {
+  log_trace("");
   return multiply_compute(mkl::par, std::forward<operation_info_t>(info),
                           std::forward<A>(a), std::forward<B>(b),
                           std::forward<C>(c));

--- a/include/spblas/vendor/onemkl_sycl/spmm_impl.hpp
+++ b/include/spblas/vendor/onemkl_sycl/spmm_impl.hpp
@@ -137,6 +137,7 @@ template <matrix A, matrix X, matrix Y>
       std::is_same_v<typename std::remove_cvref_t<Y>::layout_type,
                      __mdspan::layout_right>)
 operation_info_t multiply_inspect(A&& a, X&& x, Y&& y) {
+  log_trace("");
   auto info = multiply_inspect(mkl::par, std::forward<A>(a), std::forward<X>(x),
                                std::forward<Y>(y));
   return info;
@@ -155,6 +156,7 @@ template <matrix A, matrix X, matrix Y>
       std::is_same_v<typename std::remove_cvref_t<Y>::layout_type,
                      __mdspan::layout_right>)
 void multiply_inspect(operation_info_t& info, A&& a, X&& x, Y&& y) {
+  log_trace("");
   multiply_inspect(mkl::par, info, std::forward<A>(a), std::forward<X>(x),
                    std::forward<Y>(y));
 }
@@ -171,6 +173,7 @@ template <matrix A, matrix X, matrix Y>
       std::is_same_v<typename std::remove_cvref_t<Y>::layout_type,
                      __mdspan::layout_right>)
 void multiply(operation_info_t& info, A&& a, X&& x, Y&& y) {
+  log_trace("");
   multiply(mkl::par, info, std::forward<A>(a), std::forward<X>(x),
            std::forward<Y>(y));
 }
@@ -188,6 +191,7 @@ template <matrix A, matrix X, matrix Y>
       std::is_same_v<typename std::remove_cvref_t<Y>::layout_type,
                      __mdspan::layout_right>)
 void multiply(A&& a, X&& x, Y&& y) {
+  log_trace("");
   operation_info_t info{};
   multiply(mkl::par, info, std::forward<A>(a), std::forward<X>(x),
            std::forward<Y>(y));

--- a/include/spblas/vendor/onemkl_sycl/spmm_impl.hpp
+++ b/include/spblas/vendor/onemkl_sycl/spmm_impl.hpp
@@ -37,9 +37,60 @@ template <typename ExecutionPolicy, matrix A, matrix X, matrix Y>
                      __mdspan::layout_right> &&
       std::is_same_v<typename std::remove_cvref_t<Y>::layout_type,
                      __mdspan::layout_right>)
-void multiply(ExecutionPolicy&& policy, A&& a, X&& x, Y&& y) {
+void multiply_inspect(ExecutionPolicy&& policy, operation_info_t& info, A&& a, X&& x, Y&& y) {
   log_trace("");
-  auto x_base = __detail::get_ultimate_base(x);
+  if (__detail::is_conjugated(x) || __detail::is_conjugated(y)) {
+    throw std::runtime_error(
+        "oneMKL SYCL backend does not support conjugated dense matrices.");
+  }
+
+  if (__detail::has_matrix_opt(a)) {
+    auto a_data = __detail::get_ultimate_base(a).values().data();
+    auto&& q = __mkl::get_queue(policy, a_data);
+
+    auto a_handle = __mkl::get_matrix_handle(q, a);
+    auto a_transpose = __mkl::get_transpose(a);
+
+    auto x_base = __detail::get_ultimate_base(x);
+
+    oneapi::mkl::sparse::optimize_gemm(q, oneapi::mkl::layout::row_major, a_transpose,
+                              oneapi::mkl::transpose::nontrans, a_handle, static_cast<std::int64_t>(x_base.extent(1)))
+        .wait();
+  }
+  else {
+    // do nothing, since it would be immediately discarded
+    log_info("No work done, since no matrix_opt to store optimized results into!");
+  }
+} // multiply_inspect
+
+template <typename ExecutionPolicy, matrix A, matrix X, matrix Y>
+  requires(
+      (__detail::has_csr_base<A> || __detail::has_csc_base<A>) &&
+      __detail::has_mdspan_matrix_base<X> && __detail::is_matrix_mdspan_v<Y> &&
+      std::is_same_v<typename __detail::ultimate_base_type_t<X>::layout_type,
+                     __mdspan::layout_right> &&
+      std::is_same_v<typename std::remove_cvref_t<Y>::layout_type,
+                     __mdspan::layout_right>)
+operation_info_t multiply_inspect(ExecutionPolicy&& policy, A&& a, X&& x, Y&& y) {
+  log_trace("");
+  operation_info_t info{};
+
+  multiply_inspect(std::forward<ExecutionPolicy>(policy), info, std::forward<A>(a), std::forward<X>(x), std::forward<Y>(y));
+
+  return info;
+}
+
+
+template <typename ExecutionPolicy, matrix A, matrix X, matrix Y>
+  requires(
+      (__detail::has_csr_base<A> || __detail::has_csc_base<A>) &&
+      __detail::has_mdspan_matrix_base<X> && __detail::is_matrix_mdspan_v<Y> &&
+      std::is_same_v<typename __detail::ultimate_base_type_t<X>::layout_type,
+                     __mdspan::layout_right> &&
+      std::is_same_v<typename std::remove_cvref_t<Y>::layout_type,
+                     __mdspan::layout_right>)
+void multiply(ExecutionPolicy&& policy, operation_info_t& info, A&& a, X&& x, Y&& y) {
+  log_trace("");
 
   if (__detail::is_conjugated(x) || __detail::is_conjugated(y)) {
     throw std::runtime_error(
@@ -55,6 +106,8 @@ void multiply(ExecutionPolicy&& policy, A&& a, X&& x, Y&& y) {
   auto a_handle = __mkl::get_matrix_handle(q, a);
   auto a_transpose = __mkl::get_transpose(a);
 
+  auto x_base = __detail::get_ultimate_base(x);
+
   oneapi::mkl::sparse::gemm(q, oneapi::mkl::layout::row_major, a_transpose,
                             oneapi::mkl::transpose::nontrans, alpha, a_handle,
                             x_base.data_handle(), x_base.extent(1),
@@ -66,6 +119,60 @@ void multiply(ExecutionPolicy&& policy, A&& a, X&& x, Y&& y) {
   }
 }
 
+
+//
+// multiply_inspect - CSR/CSC with row major dense matrix rhs without execution policy
+//
+template <matrix A, matrix X, matrix Y>
+  requires(
+      (__detail::has_csr_base<A> || __detail::has_csc_base<A>) &&
+      __detail::has_mdspan_matrix_base<X> && __detail::is_matrix_mdspan_v<Y> &&
+      std::is_same_v<typename __detail::ultimate_base_type_t<X>::layout_type,
+                     __mdspan::layout_right> &&
+      std::is_same_v<typename std::remove_cvref_t<Y>::layout_type,
+                     __mdspan::layout_right>)
+operation_info_t multiply_inspect(A&& a, X&& x, Y&& y) {
+  auto info = multiply_inspect(mkl::par, std::forward<A>(a), 
+       std::forward<X>(x), std::forward<Y>(y));
+  return info;
+}
+
+//
+// multiply_inspect - CSR/CSC with row major dense matrix rhs without execution policy
+//
+template <matrix A, matrix X, matrix Y>
+  requires(
+      (__detail::has_csr_base<A> || __detail::has_csc_base<A>) &&
+      __detail::has_mdspan_matrix_base<X> && __detail::is_matrix_mdspan_v<Y> &&
+      std::is_same_v<typename __detail::ultimate_base_type_t<X>::layout_type,
+                     __mdspan::layout_right> &&
+      std::is_same_v<typename std::remove_cvref_t<Y>::layout_type,
+                     __mdspan::layout_right>)
+void multiply_inspect(operation_info_t& info, A&& a, X&& x, Y&& y) {
+  multiply_inspect(mkl::par, info, std::forward<A>(a), std::forward<X>(x),
+           std::forward<Y>(y));
+}
+
+
+//
+// multiply - CSR/CSC with row major dense matrix rhs without execution policy
+//
+template <matrix A, matrix X, matrix Y>
+  requires(
+      (__detail::has_csr_base<A> || __detail::has_csc_base<A>) &&
+      __detail::has_mdspan_matrix_base<X> && __detail::is_matrix_mdspan_v<Y> &&
+      std::is_same_v<typename __detail::ultimate_base_type_t<X>::layout_type,
+                     __mdspan::layout_right> &&
+      std::is_same_v<typename std::remove_cvref_t<Y>::layout_type,
+                     __mdspan::layout_right>)
+void multiply(operation_info_t& info, A&& a, X&& x, Y&& y) {
+  multiply(mkl::par, info, std::forward<A>(a), std::forward<X>(x),
+           std::forward<Y>(y));
+}
+
+//
+// multiply - CSR/CSC with row major dense matrix rhs without execution policy or state object
+//
 template <matrix A, matrix X, matrix Y>
   requires(
       (__detail::has_csr_base<A> || __detail::has_csc_base<A>) &&
@@ -75,8 +182,10 @@ template <matrix A, matrix X, matrix Y>
       std::is_same_v<typename std::remove_cvref_t<Y>::layout_type,
                      __mdspan::layout_right>)
 void multiply(A&& a, X&& x, Y&& y) {
-  multiply(mkl::par, std::forward<A>(a), std::forward<X>(x),
+  operation_info_t info{};
+  multiply(mkl::par, info, std::forward<A>(a), std::forward<X>(x),
            std::forward<Y>(y));
 }
+
 
 } // namespace spblas

--- a/include/spblas/vendor/onemkl_sycl/spmm_impl.hpp
+++ b/include/spblas/vendor/onemkl_sycl/spmm_impl.hpp
@@ -37,7 +37,8 @@ template <typename ExecutionPolicy, matrix A, matrix X, matrix Y>
                      __mdspan::layout_right> &&
       std::is_same_v<typename std::remove_cvref_t<Y>::layout_type,
                      __mdspan::layout_right>)
-void multiply_inspect(ExecutionPolicy&& policy, operation_info_t& info, A&& a, X&& x, Y&& y) {
+void multiply_inspect(ExecutionPolicy&& policy, operation_info_t& info, A&& a,
+                      X&& x, Y&& y) {
   log_trace("");
   if (__detail::is_conjugated(x) || __detail::is_conjugated(y)) {
     throw std::runtime_error(
@@ -53,13 +54,15 @@ void multiply_inspect(ExecutionPolicy&& policy, operation_info_t& info, A&& a, X
 
     auto x_base = __detail::get_ultimate_base(x);
 
-    oneapi::mkl::sparse::optimize_gemm(q, oneapi::mkl::layout::row_major, a_transpose,
-                              oneapi::mkl::transpose::nontrans, a_handle, static_cast<std::int64_t>(x_base.extent(1)))
+    oneapi::mkl::sparse::optimize_gemm(
+        q, oneapi::mkl::layout::row_major, a_transpose,
+        oneapi::mkl::transpose::nontrans, a_handle,
+        static_cast<std::int64_t>(x_base.extent(1)))
         .wait();
-  }
-  else {
+  } else {
     // do nothing, since it would be immediately discarded
-    log_info("No work done, since no matrix_opt to store optimized results into!");
+    log_info(
+        "No work done, since no matrix_opt to store optimized results into!");
   }
 } // multiply_inspect
 
@@ -71,15 +74,16 @@ template <typename ExecutionPolicy, matrix A, matrix X, matrix Y>
                      __mdspan::layout_right> &&
       std::is_same_v<typename std::remove_cvref_t<Y>::layout_type,
                      __mdspan::layout_right>)
-operation_info_t multiply_inspect(ExecutionPolicy&& policy, A&& a, X&& x, Y&& y) {
+operation_info_t multiply_inspect(ExecutionPolicy&& policy, A&& a, X&& x,
+                                  Y&& y) {
   log_trace("");
   operation_info_t info{};
 
-  multiply_inspect(std::forward<ExecutionPolicy>(policy), info, std::forward<A>(a), std::forward<X>(x), std::forward<Y>(y));
+  multiply_inspect(std::forward<ExecutionPolicy>(policy), info,
+                   std::forward<A>(a), std::forward<X>(x), std::forward<Y>(y));
 
   return info;
 }
-
 
 template <typename ExecutionPolicy, matrix A, matrix X, matrix Y>
   requires(
@@ -89,7 +93,8 @@ template <typename ExecutionPolicy, matrix A, matrix X, matrix Y>
                      __mdspan::layout_right> &&
       std::is_same_v<typename std::remove_cvref_t<Y>::layout_type,
                      __mdspan::layout_right>)
-void multiply(ExecutionPolicy&& policy, operation_info_t& info, A&& a, X&& x, Y&& y) {
+void multiply(ExecutionPolicy&& policy, operation_info_t& info, A&& a, X&& x,
+              Y&& y) {
   log_trace("");
 
   if (__detail::is_conjugated(x) || __detail::is_conjugated(y)) {
@@ -119,9 +124,9 @@ void multiply(ExecutionPolicy&& policy, operation_info_t& info, A&& a, X&& x, Y&
   }
 }
 
-
 //
-// multiply_inspect - CSR/CSC with row major dense matrix rhs without execution policy
+// multiply_inspect - CSR/CSC with row major dense matrix rhs without execution
+// policy
 //
 template <matrix A, matrix X, matrix Y>
   requires(
@@ -132,13 +137,14 @@ template <matrix A, matrix X, matrix Y>
       std::is_same_v<typename std::remove_cvref_t<Y>::layout_type,
                      __mdspan::layout_right>)
 operation_info_t multiply_inspect(A&& a, X&& x, Y&& y) {
-  auto info = multiply_inspect(mkl::par, std::forward<A>(a), 
-       std::forward<X>(x), std::forward<Y>(y));
+  auto info = multiply_inspect(mkl::par, std::forward<A>(a), std::forward<X>(x),
+                               std::forward<Y>(y));
   return info;
 }
 
 //
-// multiply_inspect - CSR/CSC with row major dense matrix rhs without execution policy
+// multiply_inspect - CSR/CSC with row major dense matrix rhs without execution
+// policy
 //
 template <matrix A, matrix X, matrix Y>
   requires(
@@ -150,9 +156,8 @@ template <matrix A, matrix X, matrix Y>
                      __mdspan::layout_right>)
 void multiply_inspect(operation_info_t& info, A&& a, X&& x, Y&& y) {
   multiply_inspect(mkl::par, info, std::forward<A>(a), std::forward<X>(x),
-           std::forward<Y>(y));
+                   std::forward<Y>(y));
 }
-
 
 //
 // multiply - CSR/CSC with row major dense matrix rhs without execution policy
@@ -171,7 +176,8 @@ void multiply(operation_info_t& info, A&& a, X&& x, Y&& y) {
 }
 
 //
-// multiply - CSR/CSC with row major dense matrix rhs without execution policy or state object
+// multiply - CSR/CSC with row major dense matrix rhs without execution policy
+// or state object
 //
 template <matrix A, matrix X, matrix Y>
   requires(
@@ -186,6 +192,5 @@ void multiply(A&& a, X&& x, Y&& y) {
   multiply(mkl::par, info, std::forward<A>(a), std::forward<X>(x),
            std::forward<Y>(y));
 }
-
 
 } // namespace spblas

--- a/include/spblas/vendor/onemkl_sycl/spmv_impl.hpp
+++ b/include/spblas/vendor/onemkl_sycl/spmv_impl.hpp
@@ -28,7 +28,6 @@
 
 namespace spblas {
 
-
 //
 // multiply_inspect with CSR/CSC and single rhs
 //
@@ -52,15 +51,13 @@ void multiply_inspect(ExecutionPolicy&& policy, A&& a, X&& x, Y&& y) {
     auto a_transpose = __mkl::get_transpose(a);
 
     oneapi::mkl::sparse::optimize_gemv(q, a_transpose, a_handle).wait();
-  }
-  else {
+  } else {
     // do nothing, since it would be trashed immediately after
-    log_info("No work done, since no matrix_opt to store optimized results into!");
-
+    log_info(
+        "No work done, since no matrix_opt to store optimized results into!");
   }
 
 } // multiply_inspect
-
 
 //
 // multiply with CSR/CSC and single rhs
@@ -96,9 +93,8 @@ void multiply(ExecutionPolicy&& policy, A&& a, X&& x, Y&& y) {
   }
 }
 
-
 //
-// multiply_inspect -- CSR/CSC + single rhs vector 
+// multiply_inspect -- CSR/CSC + single rhs vector
 //                     with no ExecutionPolicy
 //
 template <matrix A, vector X, vector Y>
@@ -107,11 +103,11 @@ template <matrix A, vector X, vector Y>
            __ranges::contiguous_range<Y>)
 void multiply_inspect(A&& a, X&& x, Y&& y) {
   multiply_inspect(mkl::par, std::forward<A>(a), std::forward<X>(x),
-           std::forward<Y>(y));
+                   std::forward<Y>(y));
 }
 
 //
-// multiply -- CSR/CSC + single rhs vector 
+// multiply -- CSR/CSC + single rhs vector
 //
 template <matrix A, vector X, vector Y>
   requires((__detail::has_csr_base<A> || __detail::has_csc_base<A>) &&

--- a/include/spblas/vendor/onemkl_sycl/spmv_impl.hpp
+++ b/include/spblas/vendor/onemkl_sycl/spmv_impl.hpp
@@ -28,6 +28,43 @@
 
 namespace spblas {
 
+
+//
+// multiply_inspect with CSR/CSC and single rhs
+//
+template <typename ExecutionPolicy, matrix A, vector X, vector Y>
+  requires((__detail::has_csr_base<A> || __detail::has_csc_base<A>) &&
+           __detail::has_contiguous_range_base<X> &&
+           __ranges::contiguous_range<Y>)
+void multiply_inspect(ExecutionPolicy&& policy, A&& a, X&& x, Y&& y) {
+  log_trace("");
+
+  if (__detail::is_conjugated(x) || __detail::is_conjugated(y)) {
+    throw std::runtime_error(
+        "oneMKL SYCL backend does not support conjugated dense vectors.");
+  }
+
+  if (__detail::has_matrix_opt(a)) {
+    auto a_data = __detail::get_ultimate_base(a).values().data();
+    auto&& q = __mkl::get_queue(policy, a_data);
+
+    auto a_handle = __mkl::get_matrix_handle(q, a);
+    auto a_transpose = __mkl::get_transpose(a);
+
+    oneapi::mkl::sparse::optimize_gemv(q, a_transpose, a_handle).wait();
+  }
+  else {
+    // do nothing, since it would be trashed immediately after
+    log_info("No work done, since no matrix_opt to store optimized results into!");
+
+  }
+
+} // multiply_inspect
+
+
+//
+// multiply with CSR/CSC and single rhs
+//
 template <typename ExecutionPolicy, matrix A, vector X, vector Y>
   requires((__detail::has_csr_base<A> || __detail::has_csc_base<A>) &&
            __detail::has_contiguous_range_base<X> &&
@@ -45,7 +82,6 @@ void multiply(ExecutionPolicy&& policy, A&& a, X&& x, Y&& y) {
   tensor_scalar_t<A> alpha = alpha_optional.value_or(1);
 
   auto a_data = __detail::get_ultimate_base(a).values().data();
-
   auto&& q = __mkl::get_queue(policy, a_data);
 
   auto a_handle = __mkl::get_matrix_handle(q, a);
@@ -60,6 +96,23 @@ void multiply(ExecutionPolicy&& policy, A&& a, X&& x, Y&& y) {
   }
 }
 
+
+//
+// multiply_inspect -- CSR/CSC + single rhs vector 
+//                     with no ExecutionPolicy
+//
+template <matrix A, vector X, vector Y>
+  requires((__detail::has_csr_base<A> || __detail::has_csc_base<A>) &&
+           __detail::has_contiguous_range_base<X> &&
+           __ranges::contiguous_range<Y>)
+void multiply_inspect(A&& a, X&& x, Y&& y) {
+  multiply_inspect(mkl::par, std::forward<A>(a), std::forward<X>(x),
+           std::forward<Y>(y));
+}
+
+//
+// multiply -- CSR/CSC + single rhs vector 
+//
 template <matrix A, vector X, vector Y>
   requires((__detail::has_csr_base<A> || __detail::has_csc_base<A>) &&
            __detail::has_contiguous_range_base<X> &&

--- a/include/spblas/vendor/onemkl_sycl/spmv_impl.hpp
+++ b/include/spblas/vendor/onemkl_sycl/spmv_impl.hpp
@@ -102,6 +102,7 @@ template <matrix A, vector X, vector Y>
            __detail::has_contiguous_range_base<X> &&
            __ranges::contiguous_range<Y>)
 void multiply_inspect(A&& a, X&& x, Y&& y) {
+  log_trace("");
   multiply_inspect(mkl::par, std::forward<A>(a), std::forward<X>(x),
                    std::forward<Y>(y));
 }

--- a/include/spblas/vendor/onemkl_sycl/triangular_solve_impl.hpp
+++ b/include/spblas/vendor/onemkl_sycl/triangular_solve_impl.hpp
@@ -29,7 +29,8 @@ namespace spblas {
 //
 // CSR triangular solve inspection step
 //
-template <typename ExecutionPolicy, matrix A, class Triangle, class DiagonalStorage, vector B, vector X>
+template <typename ExecutionPolicy, matrix A, class Triangle,
+          class DiagonalStorage, vector B, vector X>
   requires __detail::has_csr_base<A> &&
            __detail::has_contiguous_range_base<B> &&
            __ranges::contiguous_range<X>
@@ -65,19 +66,19 @@ void triangular_solve_inspect(ExecutionPolicy&& policy, A&& a, Triangle uplo,
                       ? oneapi::mkl::diag::nonunit
                       : oneapi::mkl::diag::unit;
 
-  oneapi::mkl::sparse::optimize_trsv(q, uplo_val, a_op, diag_val, a_handle).wait();
+  oneapi::mkl::sparse::optimize_trsv(q, uplo_val, a_op, diag_val, a_handle)
+      .wait();
 
   if (!__detail::has_matrix_opt(a)) {
     oneapi::mkl::sparse::release_matrix_handle(q, &a_handle).wait();
   }
-
 }
-
 
 //
 // CSR triangular solve execution step
 //
-template <typename ExecutionPolicy, matrix A, class Triangle, class DiagonalStorage, vector B, vector X>
+template <typename ExecutionPolicy, matrix A, class Triangle,
+          class DiagonalStorage, vector B, vector X>
   requires __detail::has_csr_base<A> &&
            __detail::has_contiguous_range_base<B> &&
            __ranges::contiguous_range<X>
@@ -107,10 +108,9 @@ void triangular_solve(ExecutionPolicy&& policy, A&& a, Triangle uplo,
   auto a_handle = __mkl::get_matrix_handle(q, a);
   auto a_op = __mkl::get_transpose(a);
 
-  auto uplo_val =
-      std::is_same_v<Triangle, upper_triangle_t>
-          ? oneapi::mkl::uplo::upper
-          : oneapi::mkl::uplo::lower;
+  auto uplo_val = std::is_same_v<Triangle, upper_triangle_t>
+                      ? oneapi::mkl::uplo::upper
+                      : oneapi::mkl::uplo::lower;
 
   auto diag_val = std::is_same_v<DiagonalStorage, explicit_diagonal_t>
                       ? oneapi::mkl::diag::nonunit
@@ -128,8 +128,6 @@ void triangular_solve(ExecutionPolicy&& policy, A&& a, Triangle uplo,
 
 } // triangular_solve
 
-
-
 //
 // CSR triangular_solve_inspect with no exception policy
 //
@@ -137,16 +135,13 @@ template <matrix A, class Triangle, class DiagonalStorage, vector B, vector X>
   requires __detail::has_csr_base<A> &&
            __detail::has_contiguous_range_base<B> &&
            __ranges::contiguous_range<X>
-void triangular_solve_inspect(A&& a, Triangle uplo,
-                              DiagonalStorage diag, B&& b, X&& x) {
-    triangular_solve_inspect(mkl::par,
-                             std::forward<A>(a),
-                             std::forward<Triangle>(uplo),
-                             std::forward<DiagonalStorage>(diag),
-                             std::forward<B>(b),
-                             std::forward<X>(x) );
+void triangular_solve_inspect(A&& a, Triangle uplo, DiagonalStorage diag, B&& b,
+                              X&& x) {
+  triangular_solve_inspect(mkl::par, std::forward<A>(a),
+                           std::forward<Triangle>(uplo),
+                           std::forward<DiagonalStorage>(diag),
+                           std::forward<B>(b), std::forward<X>(x));
 } // triangular_solve_inspect
-
 
 //
 // CSR triangular_solve with no exception policy
@@ -155,15 +150,11 @@ template <matrix A, class Triangle, class DiagonalStorage, vector B, vector X>
   requires __detail::has_csr_base<A> &&
            __detail::has_contiguous_range_base<B> &&
            __ranges::contiguous_range<X>
-void triangular_solve(A&& a, Triangle uplo,
-                      DiagonalStorage diag, B&& b, X&& x) {
-    triangular_solve(mkl::par,
-                     std::forward<A>(a),
-                     std::forward<Triangle>(uplo),
-                     std::forward<DiagonalStorage>(diag),
-                     std::forward<B>(b),
-                     std::forward<X>(x) );
+void triangular_solve(A&& a, Triangle uplo, DiagonalStorage diag, B&& b,
+                      X&& x) {
+  triangular_solve(mkl::par, std::forward<A>(a), std::forward<Triangle>(uplo),
+                   std::forward<DiagonalStorage>(diag), std::forward<B>(b),
+                   std::forward<X>(x));
 } // triangular_solve
-
 
 } // namespace spblas

--- a/include/spblas/vendor/onemkl_sycl/triangular_solve_impl.hpp
+++ b/include/spblas/vendor/onemkl_sycl/triangular_solve_impl.hpp
@@ -26,40 +26,35 @@ namespace spblas {
 //  lower + conjtrans (D+U)^H   ->   conjtrans + upper (D+U)^H
 //
 
-template <matrix A, class Triangle, class DiagonalStorage, vector B, vector X>
+//
+// CSR triangular solve inspection step
+//
+template <typename ExecutionPolicy, matrix A, class Triangle, class DiagonalStorage, vector B, vector X>
   requires __detail::has_csr_base<A> &&
            __detail::has_contiguous_range_base<B> &&
            __ranges::contiguous_range<X>
-void triangular_solve(A&& a, Triangle uplo, DiagonalStorage diag, B&& b,
-                      X&& x) {
+void triangular_solve_inspect(ExecutionPolicy&& policy, A&& a, Triangle uplo,
+                              DiagonalStorage diag, B&& b, X&& x) {
   log_trace("");
   static_assert(std::is_same_v<Triangle, upper_triangle_t> ||
                 std::is_same_v<Triangle, lower_triangle_t>);
   static_assert(std::is_same_v<DiagonalStorage, explicit_diagonal_t> ||
                 std::is_same_v<DiagonalStorage, implicit_unit_diagonal_t>);
 
-  auto a_base = __detail::get_ultimate_base(a);
-  auto b_base = __detail::get_ultimate_base(b);
+  if (__detail::is_conjugated(b) || __detail::is_conjugated(x)) {
+    throw std::runtime_error(
+        "oneMKL SYCL backend does not support conjugated dense vectors.");
+  }
 
   using T = tensor_scalar_t<A>;
   using I = tensor_index_t<A>;
   using O = tensor_offset_t<A>;
 
-  auto alpha_optional = __detail::get_scaling_factor(a, b);
-  T alpha = alpha_optional.value_or(1);
+  auto a_data = __detail::get_ultimate_base(a).values().data();
+  auto&& q = __mkl::get_queue(policy, a_data);
 
-  sycl::queue q(sycl::cpu_selector_v);
-
-  oneapi::mkl::sparse::matrix_handle_t a_handle = nullptr;
-  oneapi::mkl::sparse::init_matrix_handle(&a_handle);
-
-  oneapi::mkl::sparse::set_csr_data(
-      q, a_handle, __backend::shape(a_base)[0], __backend::shape(a_base)[1],
-      oneapi::mkl::index_base::zero, a_base.rowptr().data(),
-      a_base.colind().data(), a_base.values().data())
-      .wait();
-
-  auto op = oneapi::mkl::transpose::nontrans;
+  auto a_handle = __mkl::get_matrix_handle(q, a);
+  auto a_op = __mkl::get_transpose(a);
 
   auto uplo_val =
       std::is_same_v<Triangle, upper_triangle_t>
@@ -70,12 +65,105 @@ void triangular_solve(A&& a, Triangle uplo, DiagonalStorage diag, B&& b,
                       ? oneapi::mkl::diag::nonunit
                       : oneapi::mkl::diag::unit;
 
-  oneapi::mkl::sparse::trsv(q, uplo_val, op, diag_val, alpha, a_handle,
+  oneapi::mkl::sparse::optimize_trsv(q, uplo_val, a_op, diag_val, a_handle).wait();
+
+  if (!__detail::has_matrix_opt(a)) {
+    oneapi::mkl::sparse::release_matrix_handle(q, &a_handle).wait();
+  }
+
+}
+
+
+//
+// CSR triangular solve execution step
+//
+template <typename ExecutionPolicy, matrix A, class Triangle, class DiagonalStorage, vector B, vector X>
+  requires __detail::has_csr_base<A> &&
+           __detail::has_contiguous_range_base<B> &&
+           __ranges::contiguous_range<X>
+void triangular_solve(ExecutionPolicy&& policy, A&& a, Triangle uplo,
+                      DiagonalStorage diag, B&& b, X&& x) {
+  log_trace("");
+  static_assert(std::is_same_v<Triangle, upper_triangle_t> ||
+                std::is_same_v<Triangle, lower_triangle_t>);
+  static_assert(std::is_same_v<DiagonalStorage, explicit_diagonal_t> ||
+                std::is_same_v<DiagonalStorage, implicit_unit_diagonal_t>);
+
+  if (__detail::is_conjugated(b) || __detail::is_conjugated(x)) {
+    throw std::runtime_error(
+        "oneMKL SYCL backend does not support conjugated dense vectors.");
+  }
+
+  using T = tensor_scalar_t<A>;
+  using I = tensor_index_t<A>;
+  using O = tensor_offset_t<A>;
+
+  auto alpha_optional = __detail::get_scaling_factor(a, b);
+  tensor_scalar_t<A> alpha = alpha_optional.value_or(1);
+
+  auto a_data = __detail::get_ultimate_base(a).values().data();
+  auto&& q = __mkl::get_queue(policy, a_data);
+
+  auto a_handle = __mkl::get_matrix_handle(q, a);
+  auto a_op = __mkl::get_transpose(a);
+
+  auto uplo_val =
+      std::is_same_v<Triangle, upper_triangle_t>
+          ? oneapi::mkl::uplo::upper
+          : oneapi::mkl::uplo::lower;
+
+  auto diag_val = std::is_same_v<DiagonalStorage, explicit_diagonal_t>
+                      ? oneapi::mkl::diag::nonunit
+                      : oneapi::mkl::diag::unit;
+
+  auto b_base = __detail::get_ultimate_base(b);
+
+  oneapi::mkl::sparse::trsv(q, uplo_val, a_op, diag_val, alpha, a_handle,
                             __ranges::data(b_base), __ranges::data(x))
       .wait();
 
-  oneapi::mkl::sparse::release_matrix_handle(q, &a_handle).wait();
+  if (!__detail::has_matrix_opt(a)) {
+    oneapi::mkl::sparse::release_matrix_handle(q, &a_handle).wait();
+  }
 
 } // triangular_solve
+
+
+
+//
+// CSR triangular_solve_inspect with no exception policy
+//
+template <matrix A, class Triangle, class DiagonalStorage, vector B, vector X>
+  requires __detail::has_csr_base<A> &&
+           __detail::has_contiguous_range_base<B> &&
+           __ranges::contiguous_range<X>
+void triangular_solve_inspect(A&& a, Triangle uplo,
+                              DiagonalStorage diag, B&& b, X&& x) {
+    triangular_solve_inspect(mkl::par,
+                             std::forward<A>(a),
+                             std::forward<Triangle>(uplo),
+                             std::forward<DiagonalStorage>(diag),
+                             std::forward<B>(b),
+                             std::forward<X>(x) );
+} // triangular_solve_inspect
+
+
+//
+// CSR triangular_solve with no exception policy
+//
+template <matrix A, class Triangle, class DiagonalStorage, vector B, vector X>
+  requires __detail::has_csr_base<A> &&
+           __detail::has_contiguous_range_base<B> &&
+           __ranges::contiguous_range<X>
+void triangular_solve(A&& a, Triangle uplo,
+                      DiagonalStorage diag, B&& b, X&& x) {
+    triangular_solve(mkl::par,
+                     std::forward<A>(a),
+                     std::forward<Triangle>(uplo),
+                     std::forward<DiagonalStorage>(diag),
+                     std::forward<B>(b),
+                     std::forward<X>(x) );
+} // triangular_solve
+
 
 } // namespace spblas


### PR DESCRIPTION

**Summary:**
    1. add spmm_csr and sptrsv_csr examples with more complete API usage models (using operation_info_t and inspect functions)
    2. add xyz_inspect and operation_info_t, and matrix_opt to ONEMKL_SYCL backend
    3. add several more variants of reference function with more complete set of apis

**Merge Checklist:**

 - [x] Passing CI
 - [x] Update documentation or README.md
 - [x] Additional Test/example added (if applicable) and passing
 - [x] At least one reviewer approval
 - [ ] (optional) Clang sanitizer scan run and triaged
 - [x] Clang formatter applied (verified as part of passing CI)
