### PR TITLE
add initial legacy pattern corresponding concept and helper function

### DIFF
--- a/include/spblas/concepts.hpp
+++ b/include/spblas/concepts.hpp
@@ -4,6 +4,7 @@
 #include <spblas/detail/concepts.hpp>
 #include <spblas/detail/ranges.hpp>
 #include <spblas/views/inspectors.hpp>
+#include <spblas/views/matrix_view.hpp>
 #include <spblas/views/view_base.hpp>
 
 namespace spblas {
@@ -18,7 +19,8 @@ namespace spblas {
 */
 
 template <typename M>
-concept matrix = __detail::is_csr_view_v<M> || __detail::is_csc_view_v<M> ||
+concept matrix = matrix_view::is_legacy_pattern_v<M> ||
+                 __detail::is_csr_view_v<M> || __detail::is_csc_view_v<M> ||
                  __detail::is_matrix_mdspan_v<M> || __detail::matrix<M>;
 
 /*

--- a/include/spblas/detail/view_inspectors.hpp
+++ b/include/spblas/detail/view_inspectors.hpp
@@ -5,6 +5,7 @@
 
 #include <spblas/detail/concepts.hpp>
 #include <spblas/views/inspectors.hpp>
+#include <spblas/views/matrix_view.hpp>
 
 namespace spblas {
 
@@ -111,11 +112,44 @@ auto get_ultimate_base(T&& t) {
 }
 
 template <tensor T>
+auto get_ultimate_base_or_matrix_opt(T&& t) {
+  if constexpr (is_matrix_opt_v<T>) {
+    return t;
+  } else if constexpr (has_base<T>) {
+    return get_ultimate_base_or_matrix_opt(t.base());
+  } else {
+    return t;
+  }
+}
+
+template <tensor T>
+auto get_ultimate_base_or_matrix(T&& t) {
+  if constexpr (matrix_view::is_legacy_pattern_v<T>) {
+    return t;
+  } else if constexpr (has_base<T>) {
+    return get_ultimate_base_or_matrix(t.base());
+  } else {
+    return t;
+  }
+}
+
+template <tensor T>
 bool has_matrix_opt(T&& t) {
   if constexpr (is_matrix_opt_v<T>) {
     return true;
   } else if constexpr (has_base<T>) {
     return has_matrix_opt(t.base());
+  } else {
+    return false;
+  }
+}
+
+template <tensor T>
+bool has_legacy_pattern(T&& t) {
+  if constexpr (matrix_view::is_legacy_pattern_v<T>) {
+    return true;
+  } else if constexpr (has_base<T>) {
+    return has_legacy_pattern(t.base());
   } else {
     return false;
   }
@@ -136,6 +170,20 @@ concept has_mdspan_matrix_base = is_matrix_mdspan_v<ultimate_base_type_t<T>>;
 template <typename T>
 concept has_contiguous_range_base =
     spblas::__ranges::contiguous_range<ultimate_base_type_t<T>>;
+
+template <typename T>
+using ultimate_base_or_matrix_type_t =
+    decltype(get_ultimate_base_or_matrix(std::declval<T>()));
+
+template <typename T>
+concept has_legacy_pattern_d =
+    matrix_view::is_legacy_pattern_v<ultimate_base_or_matrix_type_t<T>>;
+
+template <typename T>
+concept has_full =
+    !has_legacy_pattern_d<T> ||
+    std::is_same_v<typename ultimate_base_or_matrix_type_t<T>::uplo,
+                   matrix_view::uplo::full>;
 
 } // namespace __detail
 

--- a/include/spblas/vendor/onemkl_sycl/spmm_impl.hpp
+++ b/include/spblas/vendor/onemkl_sycl/spmm_impl.hpp
@@ -92,7 +92,8 @@ template <typename ExecutionPolicy, matrix A, matrix X, matrix Y>
       std::is_same_v<typename __detail::ultimate_base_type_t<X>::layout_type,
                      __mdspan::layout_right> &&
       std::is_same_v<typename std::remove_cvref_t<Y>::layout_type,
-                     __mdspan::layout_right>)
+                     __mdspan::layout_right> &&
+      __detail::has_full<A>)
 void multiply(ExecutionPolicy&& policy, operation_info_t& info, A&& a, X&& x,
               Y&& y) {
   log_trace("");

--- a/include/spblas/views/matrix_view.hpp
+++ b/include/spblas/views/matrix_view.hpp
@@ -93,6 +93,22 @@ private:
   matrix_opt& obj;
 };
 
+template <typename T>
+struct is_instantiation_of_legacy_pattern {
+  static constexpr bool value = false;
+};
+
+template <typename matrix_opt, typename Conjugate, typename Transpose,
+          diag::diag Diagonal, uplo::uplo UpLo>
+struct is_instantiation_of_legacy_pattern<
+    legacy_pattern<matrix_opt, Conjugate, Transpose, Diagonal, UpLo>> {
+  static constexpr bool value = true;
+};
+
+template <typename T>
+static constexpr bool is_legacy_pattern_v =
+    is_instantiation_of_legacy_pattern<std::remove_cvref_t<T>>::value;
+
 template <typename matrix_opt>
 auto conjugate(matrix_opt&& matrix) {
   return legacy_pattern<matrix_opt, std::true_type>(matrix);


### PR DESCRIPTION
**Summary:**
    This add some helper function and concept usage such that we can use the legacy pattern information to distinguish the implementation

**Details:**

 - `get_ultimate_base_or_matrix_opt` is different than the other kind of `get_..._matrix`. It stops at the matrix_opt not the matrix_view. We might need both eventually for input with matrix_opt and output with matrix_view
 - We need to keep the reference. Otherwise, when we try to create the matrix_handle in matrix_opt, it use copy constructor such that it leads the handle actually released. (Personally, I would prefer using shared_ptr to let it handle lifetime. Otherwise, we must handle them carefully. Related to #67)
 - It introduces `has_full` to show that we can limit the implementation only when the matrix if full as provided.
 - There is something we need to unify to make consistent behavior but here is the proof of concept about the usage.

**Merge Checklist:**

 - [ ] Passing CI
 - [ ] Update documentation or README.md
 - [ ] Additional Test/example added (if applicable) and passing
 - [ ] At least one reviewer approval
 - [ ] (optional) Clang sanitizer scan run and triaged
 - [ ] Clang formatter applied (verified as part of passing CI)
