### PR TITLE
apply legacy pattern to triangular solve

### DIFF
--- a/include/spblas/vendor/onemkl_sycl/triangular_solve_impl.hpp
+++ b/include/spblas/vendor/onemkl_sycl/triangular_solve_impl.hpp
@@ -8,6 +8,7 @@
 #include <spblas/detail/view_inspectors.hpp>
 
 #include <spblas/detail/triangular_types.hpp>
+#include <spblas/views/matrix_view.hpp>
 
 namespace spblas {
 
@@ -74,6 +75,24 @@ void triangular_solve_inspect(ExecutionPolicy&& policy, A&& a, Triangle uplo,
   }
 }
 
+template <typename ExecutionPolicy, matrix A, vector B, vector X>
+  requires __detail::has_csr_base<A> &&
+           __detail::has_contiguous_range_base<B> &&
+           __ranges::contiguous_range<X>
+void triangular_solve_inspect(ExecutionPolicy&& policy, A&& a, B&& b, X&& x) {
+  log_trace("");
+  using type = decltype(matrix_view::legacy_pattern(a));
+  triangular_solve_inspect(
+      policy, __detail::get_ultimate_base_or_matrix_opt(a),
+      std::conditional_t<
+          std::is_same_v<typename type::uplo, matrix_view::uplo::upper>,
+          upper_triangle_t, lower_triangle_t>{},
+      std::conditional_t<
+          std::is_same_v<typename type::diag, matrix_view::diag::explicit_diag>,
+          explicit_diagonal_t, implicit_unit_diagonal_t>{},
+      b, x);
+}
+
 //
 // CSR triangular solve execution step
 //
@@ -128,6 +147,30 @@ void triangular_solve(ExecutionPolicy&& policy, A&& a, Triangle uplo,
 
 } // triangular_solve
 
+template <typename ExecutionPolicy, matrix A, vector B, vector X>
+  requires __detail::has_csr_base<A> &&
+           __detail::has_contiguous_range_base<B> &&
+           __ranges::contiguous_range<X> && __detail::has_legacy_pattern_d<A> &&
+           (!std::is_same_v<
+               typename __detail::ultimate_base_or_matrix_type_t<A>::diag,
+               matrix_view::diag::implicit_zero>) &&
+           (!std::is_same_v<
+               typename __detail::ultimate_base_or_matrix_type_t<A>::uplo,
+               matrix_view::uplo::full>)
+void triangular_solve(ExecutionPolicy&& policy, A&& a, B&& b, X&& x) {
+  log_trace("");
+  using type = decltype(matrix_view::legacy_pattern(a));
+  triangular_solve(
+      policy, __detail::get_ultimate_base_or_matrix_opt(a),
+      std::conditional_t<
+          std::is_same_v<typename type::uplo, matrix_view::uplo::upper>,
+          upper_triangle_t, lower_triangle_t>{},
+      std::conditional_t<
+          std::is_same_v<typename type::diag, matrix_view::diag::explicit_diag>,
+          explicit_diagonal_t, implicit_unit_diagonal_t>{},
+      b, x);
+}
+
 //
 // CSR triangular_solve_inspect with no exception policy
 //
@@ -156,5 +199,20 @@ void triangular_solve(A&& a, Triangle uplo, DiagonalStorage diag, B&& b,
                    std::forward<DiagonalStorage>(diag), std::forward<B>(b),
                    std::forward<X>(x));
 } // triangular_solve
+
+template <matrix A, vector B, vector X>
+  requires __detail::has_csr_base<A> &&
+           __detail::has_contiguous_range_base<B> &&
+           __ranges::contiguous_range<X> && __detail::has_legacy_pattern_d<A> &&
+           (!std::is_same_v<
+               typename __detail::ultimate_base_or_matrix_type_t<A>::diag,
+               matrix_view::diag::implicit_zero>) &&
+           (!std::is_same_v<
+               typename __detail::ultimate_base_or_matrix_type_t<A>::uplo,
+               matrix_view::uplo::full>)
+void triangular_solve(A&& a, B&& b, X&& x) {
+  triangular_solve(mkl::par, std::forward<A>(a), std::forward<B>(b),
+                   std::forward<X>(x));
+}
 
 } // namespace spblas

--- a/include/spblas/views/matrix_view.hpp
+++ b/include/spblas/views/matrix_view.hpp
@@ -79,6 +79,11 @@ template <typename matrix_opt, typename Conjugate = std::false_type,
           uplo::uplo UpLo = uplo::full>
 class legacy_pattern : public spblas::view_base {
 public:
+  using uplo = UpLo;
+  using diag = Diagonal;
+  using conjugate = Conjugate;
+  using transpose = Transpose;
+
   legacy_pattern(matrix_opt&& t) : obj(t) {}
 
   auto& base() {

--- a/test/gtest/triangular_solve_test.cpp
+++ b/test/gtest/triangular_solve_test.cpp
@@ -75,7 +75,20 @@ void triangular_solve_test(Triangle t, DiagonalStorage d) {
     std::transform(values.begin(), values.end(), values.begin(),
                    [scale_factor](T val) { return scale_factor * val; });
 
-    spblas::triangular_solve(a, Triangle{}, DiagonalStorage{}, b, x);
+    // we only have upper/lower for Triangle and implicit_one, explicit for
+    // DiagonalStorage originally.
+    using uplo =
+        std::conditional_t<std::is_same_v<Triangle, spblas::lower_triangle_t>,
+                           spblas::matrix_view::uplo::lower,
+                           spblas::matrix_view::uplo::upper>;
+    using diag = std::conditional_t<
+        std::is_same_v<DiagonalStorage, spblas::implicit_unit_diagonal_t>,
+        spblas::matrix_view::diag::implicit_unit,
+        spblas::matrix_view::diag::explicit_diag>;
+    spblas::triangular_solve(spblas::matrix_view::triangle(a, uplo{}, diag{}),
+                             b, x);
+
+    // spblas::triangular_solve(a, Triangle{}, DiagonalStorage{}, b, x);
 
     std::vector<T> x_ref(m, 0);
 


### PR DESCRIPTION
**Summary:**
    This PR applies legacy pattern to triangular solve in test.
    This is mainly to check the usage whether makes our expectation

**Details:**

 - use legacy pattern in triangular solve

**Merge Checklist:**

 - [ ] Passing CI
 - [ ] Update documentation or README.md
 - [ ] Additional Test/example added (if applicable) and passing
 - [ ] At least one reviewer approval
 - [ ] (optional) Clang sanitizer scan run and triaged
 - [ ] Clang formatter applied (verified as part of passing CI)
